### PR TITLE
Make --version non global

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,4 +1,5 @@
 import yargs from 'yargs'
+import {log} from './utils/log'
 import {version} from '../package.json'
 
 yargs.usage('\nUsage: contentful <cmd> [args]')
@@ -9,6 +10,17 @@ yargs.usage('\nUsage: contentful <cmd> [args]')
   .alias('h', 'help')
   .strict()
   .recommendCommands()
-  .version(version)
+  .option('v', {
+    alias: 'version',
+    global: false,
+    type: 'boolean',
+    describe: 'Show current version'
+  })
   .epilog('Copyright 2017 Contentful, this is a BETA release')
-  .parse(process.argv.slice(2))
+  .parse(process.argv.slice(2), (_, argv, output) => {
+    if (argv.version === true && !argv._.length) {
+      log(version)
+    } else {
+      log(output)
+    }
+  })


### PR DESCRIPTION
This PR makes the --version flag non-global. It should only work with the top level command, e.g. `contentful --version`

It's required for https://github.com/contentful/contentful-cli/pull/2 since `--version` has a different meaning for some commands.
