### PR TITLE
 fix: Use space id from cmdline 

### DIFF
--- a/lib/cmds/space_cmds/use.js
+++ b/lib/cmds/space_cmds/use.js
@@ -37,7 +37,7 @@ export async function spaceUse (argv) {
   const client = await createManagementClient({
     accessToken: cmaToken
   })
-  
+
   if (spaceId) {
     const space = await client.getSpace(spaceId)
     


### PR DESCRIPTION
The space id is not saved in the general config file, if given on command line.

This PR should fix that ... :)

```
contentful space use --space-id foobar
```
Did _not_ update the config in `~/.contentfulrc.json`...