### PR TITLE
fix(extensions): overwrite src & srcdoc via cmd args

### DIFF
--- a/lib/cmds/extension_cmds/utils/prepare-data.js
+++ b/lib/cmds/extension_cmds/utils/prepare-data.js
@@ -10,6 +10,14 @@ export default async function prepareData (argv) {
   const args = getExtensionData(argv)
   const descriptorArgs = getExtensionData(descriptor)
 
+  // Enable overwriting the src or srcdoc via command arguments.
+  // Will allow passing localhost as src for development and
+  // using a html file via srcdoc for production.
+  if ('src' in args || 'srcdoc' in args) {
+    delete descriptorArgs.src
+    delete descriptorArgs.srcdoc
+  }
+
   const id = argv.id || descriptor.id
 
   return {

--- a/test/unit/cmds/extension_cmds/create.test.js
+++ b/test/unit/cmds/extension_cmds/create.test.js
@@ -148,6 +148,30 @@ test('Creates extension with values from descriptor file', async (t) => {
   t.true(successStub.calledWith(`${successEmoji} Successfully created extension:\n`))
 })
 
+test('Creates extension, descriptor src is overwritten by args srcdoc', async (t) => {
+  const descriptor = `{
+    "name": "Test Extension",
+    "fieldTypes": ["Boolean"],
+    "src": "https://new.extension"
+  }`
+
+  prepareDataRewireAPI.__Rewire__('readFileP', stub().returns(
+    Promise.resolve(descriptor)
+  ))
+
+  await createExtension({ descriptor: 'test.json', srcdoc: resolve(__dirname, 'sample-extension.html') })
+
+  t.true(createUiExtensionStub.calledWith({
+    extension: {
+      name: 'Test Extension',
+      srcdoc: '<h1>Sample Extension Content</h1>\n',
+      fieldTypes: [{type: 'Boolean'}]
+    }
+  }))
+
+  t.true(successStub.calledWith(`${successEmoji} Successfully created extension:\n`))
+})
+
 test('Creates extension and reads srcdoc from disk', async (t) => {
   await createExtension({
     spaceId: 'space',


### PR DESCRIPTION
## Summary

Easy up developing UI extensions

## Description

If `src` or `srcdoc` args set via CLI, any of these values get removed from the descriptor file to allow overwriting and avoid `Must contain exactly one of: src, srcdoc`
