### PR TITLE
Drop unnecessary babel dependencies 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,12 +7,7 @@
     }]
   ],
   "plugins": [
-    "transform-object-rest-spread",
-    ["transform-runtime", {
-      "helpers": false,
-      "polyfill": false,
-      "regenerator": true
-    }]
+    "transform-object-rest-spread"
   ],
   "env": {
     "test": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
     "@ava/babel-preset-stage-4": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-1.1.0.tgz",
-      "integrity": "sha1-rmC+iBoLq/fTX1Krp3DR9hlPdr0=",
+      "integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
       "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
@@ -63,7 +63,7 @@
     "@ava/write-file-atomic": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ava/write-file-atomic/-/write-file-atomic-2.2.0.tgz",
-      "integrity": "sha1-1iUEbzSV8fXjchNfRzkJaEtCkkc=",
+      "integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
@@ -74,7 +74,7 @@
     "@concordance/react": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@concordance/react/-/react-1.0.0.tgz",
-      "integrity": "sha1-/PPK0CDlEhv9HGHQW8NRaqwl9zQ=",
+      "integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
       "dev": true,
       "requires": {
         "arrify": "1.0.1"
@@ -472,7 +472,7 @@
         "cli-truncate": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
-          "integrity": "sha1-Ky39g8U8/TVyuH/E1DCoCK+wQIY=",
+          "integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
           "dev": true,
           "requires": {
             "slice-ansi": "1.0.0",
@@ -522,7 +522,7 @@
         "slice-ansi": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-          "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
+          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0"
@@ -531,7 +531,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -543,7 +543,7 @@
     "ava-init": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/ava-init/-/ava-init-0.2.1.tgz",
-      "integrity": "sha1-daxMhVMyYpDShm5jti+nA1aEvVg=",
+      "integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
       "dev": true,
       "requires": {
         "arr-exclude": "1.0.0",
@@ -2057,7 +2057,7 @@
     "concordance": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/concordance/-/concordance-3.0.0.tgz",
-      "integrity": "sha1-sihq9UQF/JlfxzRbCxBtjdBzyyk=",
+      "integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
       "dev": true,
       "requires": {
         "date-time": "2.1.0",
@@ -2411,7 +2411,7 @@
     "date-time": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
-      "integrity": "sha1-AobRtMdpYzs8oT4eYlWNLb3C66I=",
+      "integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
       "dev": true,
       "requires": {
         "time-zone": "1.0.0"
@@ -3120,7 +3120,7 @@
     "fast-diff": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha1-S2LEK44D3j+EhGC2OQeZIGldAVQ=",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -4530,7 +4530,7 @@
     "hullabaloo-config-manager": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/hullabaloo-config-manager/-/hullabaloo-config-manager-1.1.1.tgz",
-      "integrity": "sha1-HZEXgTEprQNf2ehHfq8GaREmn+M=",
+      "integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
       "dev": true,
       "requires": {
         "dot-prop": "4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1207,15 +1207,6 @@
         "regenerator-transform": "0.10.1"
       }
     },
-    "babel-plugin-transform-runtime": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
-      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
@@ -1302,6 +1293,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "2.5.3",
         "regenerator-runtime": "0.11.1"
@@ -2313,7 +2305,8 @@
     "core-js": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -6927,14 +6920,12 @@
         "camelcase": {
           "version": "1.2.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "center-align": {
           "version": "0.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "align-text": "0.1.4",
             "lazy-cache": "1.0.4"
@@ -6956,7 +6947,6 @@
           "version": "2.1.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "center-align": "0.1.3",
             "right-align": "0.1.3",
@@ -6966,8 +6956,7 @@
             "wordwrap": {
               "version": "0.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -7500,8 +7489,7 @@
         "lazy-cache": {
           "version": "1.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lcid": {
           "version": "1.0.0",
@@ -7963,7 +7951,6 @@
           "version": "0.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "align-text": "0.1.4"
           }
@@ -8126,7 +8113,6 @@
           "version": "2.8.29",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "source-map": "0.5.7",
             "uglify-to-browserify": "1.0.2",
@@ -8137,7 +8123,6 @@
               "version": "3.10.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "camelcase": "1.2.1",
                 "cliui": "2.1.0",
@@ -8178,8 +8163,7 @@
         "window-size": {
           "version": "0.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "wordwrap": {
           "version": "0.0.3",
@@ -9330,7 +9314,8 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.10.1",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,6 @@
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-env": "^1.4.0",
     "babel-register": "^6.24.1",
-    "babel-template": "^6.24.1",
-    "babel-types": "^6.24.1",
     "cz-conventional-changelog": "^2.0.0",
     "eslint": "^4.5.0",
     "eslint-config-standard": "^10.2.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "babel-plugin-istanbul": "^4.1.4",
     "babel-plugin-rewire": "^1.1.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.4.0",
     "babel-register": "^6.24.1",
     "babel-template": "^6.24.1",
@@ -68,7 +67,6 @@
   },
   "dependencies": {
     "axios": "^0.16.1",
-    "babel-runtime": "^6.23.0",
     "bfj": "^4.2.3",
     "blessed": "^0.1.81",
     "bluebird": "^3.5.0",


### PR DESCRIPTION
## Summary

Drops unnecessary dependencies related to babel
## Description

* `babel-runtime` and `babel-plugin-transform-runtime` can be dropped since the minimum Node.js version is 6 which already supports generators (regenerator support was the only part of `babel-plugin-transform-runtime` that was enabled)
* `babel-types` and `babel-template` aren't used. They're still indirect dependencies,

## Motivation and Context

Less dependencies is better. It doesn't have any impact on the built code.