### PR TITLE
Fix import of contentful-migration

### DIFF
--- a/lib/cmds/space_cmds/migration.js
+++ b/lib/cmds/space_cmds/migration.js
@@ -1,5 +1,5 @@
 import {getContext} from '../../context'
-import runMigration from 'contentful-migration-cli/built/bin/cli'
+import runMigration from 'contentful-migration/built/bin/cli'
 import {handleAsyncError as handle} from '../../utils/async'
 import { assertLoggedIn, assertSpaceIdProvided } from '../../utils/assertions'
 import { proxyObjectToString } from '../../utils/proxy'


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

This PR fixes the import of the `contentful-migration` library.

## Motivation and Context

In v0.12.0 of the Contentful CLI, when running commands with `contentful space migration`, an error is thrown:

```
Error: Cannot find module 'contentful-migration-cli/built/bin/cli'
```

This error was introduced when `contentful-migration-cli` was renamed to `contentful-migration`.