### PR TITLE
Make logged-in assertion check in command parameters

### DIFF
--- a/lib/cmds/boilerplate.js
+++ b/lib/cmds/boilerplate.js
@@ -46,7 +46,7 @@ async function getBoilerplates () {
 }
 
 export async function downloadBoilerplate (argv) {
-  await assertLoggedIn()
+  await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
   const { spaceId } = await normalizer(argv)
 

--- a/lib/cmds/content-type_cmds/get.js
+++ b/lib/cmds/content-type_cmds/get.js
@@ -19,7 +19,7 @@ export const builder = (yargs) => {
 }
 
 async function ctShow (argv) {
-  await assertLoggedIn()
+  await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
 
   const contentTypeId = getId(argv)

--- a/lib/cmds/content-type_cmds/list.js
+++ b/lib/cmds/content-type_cmds/list.js
@@ -20,7 +20,7 @@ export const builder = (yargs) => {
 }
 
 async function ctList (argv) {
-  await assertLoggedIn()
+  await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
 
   const { cmaToken, activeSpaceId } = await getContext()

--- a/lib/cmds/extension_cmds/create.js
+++ b/lib/cmds/extension_cmds/create.js
@@ -39,7 +39,7 @@ export const builder = (yargs) => {
 }
 
 export async function createExtension (argv) {
-  await assertLoggedIn()
+  await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
 
   const data = await prepareData(argv)

--- a/lib/cmds/extension_cmds/delete.js
+++ b/lib/cmds/extension_cmds/delete.js
@@ -28,7 +28,7 @@ export const builder = (yargs) => {
 }
 
 export async function deleteExtension (argv) {
-  await assertLoggedIn()
+  await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
 
   const { cmaToken, activeSpaceId } = await getContext()

--- a/lib/cmds/extension_cmds/get.js
+++ b/lib/cmds/extension_cmds/get.js
@@ -17,7 +17,7 @@ export const builder = (yargs) => {
 }
 
 async function getExtension (argv) {
-  await assertLoggedIn()
+  await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
 
   const { cmaToken, activeSpaceId } = await getContext()

--- a/lib/cmds/extension_cmds/list.js
+++ b/lib/cmds/extension_cmds/list.js
@@ -19,7 +19,7 @@ export const builder = (yargs) => {
 }
 
 export async function listExtensions (argv) {
-  await assertLoggedIn()
+  await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
 
   const { cmaToken, activeSpaceId } = await getContext()

--- a/lib/cmds/extension_cmds/update.js
+++ b/lib/cmds/extension_cmds/update.js
@@ -50,7 +50,7 @@ export const builder = (yargs) => {
 }
 
 export async function updateExtension (argv) {
-  await assertLoggedIn()
+  await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
 
   const data = await prepareData(argv)

--- a/lib/cmds/logout.js
+++ b/lib/cmds/logout.js
@@ -8,8 +8,8 @@ export const command = 'logout'
 
 export const desc = 'Logout from Contentful'
 
-export async function logout () {
-  await assertLoggedIn()
+export async function logout (argv) {
+  await assertLoggedIn(argv)
 
   warning('This will log you out by deleting the CMA token stored on your system.')
   const confirmed = await confirmation('Do you want to log out now?')

--- a/lib/cmds/space_cmds/accesstoken_cmds/create.js
+++ b/lib/cmds/space_cmds/accesstoken_cmds/create.js
@@ -32,7 +32,7 @@ export const builder = (yargs) => {
 }
 
 export async function accessTokenCreate (argv) {
-  await assertLoggedIn()
+  await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
   const { spaceId } = await normalizer(argv)
   const { cmaToken } = await getContext()

--- a/lib/cmds/space_cmds/accesstoken_cmds/list.js
+++ b/lib/cmds/space_cmds/accesstoken_cmds/list.js
@@ -25,7 +25,7 @@ export const builder = (yargs) => {
 export const aliases = ['ls']
 
 async function accessTokenList (argv) {
-  await assertLoggedIn()
+  await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
   const { spaceId } = await normalizer(argv)
   const { cmaToken } = await getContext()

--- a/lib/cmds/space_cmds/environment_cmds/create.js
+++ b/lib/cmds/space_cmds/environment_cmds/create.js
@@ -41,7 +41,7 @@ export const builder = (yargs) => {
 }
 
 export async function environmentCreate (argv) {
-  await assertLoggedIn()
+  await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
 
   const { cmaToken, activeSpaceId } = await getContext()

--- a/lib/cmds/space_cmds/environment_cmds/delete.js
+++ b/lib/cmds/space_cmds/environment_cmds/delete.js
@@ -28,7 +28,7 @@ export const builder = (yargs) => {
 }
 
 export async function environmentDelete (argv) {
-  await assertLoggedIn()
+  await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
 
   const { cmaToken, activeSpaceId } = await getContext()

--- a/lib/cmds/space_cmds/environment_cmds/list.js
+++ b/lib/cmds/space_cmds/environment_cmds/list.js
@@ -28,7 +28,7 @@ export const builder = (yargs) => {
 export const aliases = ['ls']
 
 export async function environmentList (argv) {
-  await assertLoggedIn()
+  await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
 
   const { cmaToken, activeSpaceId } = await getContext()

--- a/lib/cmds/space_cmds/environment_cmds/use.js
+++ b/lib/cmds/space_cmds/environment_cmds/use.js
@@ -30,7 +30,7 @@ function showSuccess (space, environment) {
 }
 
 export async function environmentUse (argv) {
-  await assertLoggedIn()
+  await assertLoggedIn(argv)
 
   const { cmaToken, activeSpaceId } = await getContext()
 

--- a/lib/cmds/space_cmds/generate_cmds/migration.js
+++ b/lib/cmds/space_cmds/generate_cmds/migration.js
@@ -264,7 +264,7 @@ const getEnvironment = async function (cmaToken, spaceId, environmentId) {
 }
 
 export async function generateMigration (argv) {
-  await assertLoggedIn()
+  await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
 
   const { cmaToken, activeSpaceId, activeEnvironmentId } = await getContext()

--- a/lib/cmds/space_cmds/list.js
+++ b/lib/cmds/space_cmds/list.js
@@ -30,7 +30,7 @@ export const builder = (yargs) => {
 export const aliases = ['ls']
 
 async function spaceList (argv) {
-  await assertLoggedIn()
+  await assertLoggedIn(argv)
   const { spaceId } = await normalizer(argv)
   const { cmaToken } = await getContext()
   const managementToken = argv.managementToken || cmaToken

--- a/lib/cmds/space_cmds/use.js
+++ b/lib/cmds/space_cmds/use.js
@@ -29,7 +29,7 @@ function showSuccess (space) {
 }
 
 export async function spaceUse (argv) {
-  await assertLoggedIn()
+  await assertLoggedIn(argv)
 
   const context = await getContext()
   const { cmaToken } = context


### PR DESCRIPTION
After the `--management-token` parameter was added to the `space list` command, the `assertLoggedIn` function wasn't updated to receive the `argv` parameter, so it will always fail if no default token is found in the `.contentfulrc.json` file