### PR TITLE
Fix #65 provide environment in the get cmd

### DIFF
--- a/lib/cmds/content-type_cmds/get.js
+++ b/lib/cmds/content-type_cmds/get.js
@@ -15,7 +15,7 @@ export const builder = (yargs) => {
   return yargs
     .option('id', { type: 'string', demand: true, describe: 'Content Type id' })
     .option('space-id', { type: 'string', describe: 'Space id' })
-    .option('environment-id', { type: 'string', describe: 'Environment id' })
+    .option('environment-id', { type: 'string', describe: 'Environment id', default: 'master' })
     .epilog('Copyright 2018 Contentful, this is a BETA release')
 }
 

--- a/lib/cmds/content-type_cmds/get.js
+++ b/lib/cmds/content-type_cmds/get.js
@@ -15,6 +15,7 @@ export const builder = (yargs) => {
   return yargs
     .option('id', { type: 'string', demand: true, describe: 'Content Type id' })
     .option('space-id', { type: 'string', describe: 'Space id' })
+    .option('environment-id', { type: 'string', describe: 'Environment id' })
     .epilog('Copyright 2018 Contentful, this is a BETA release')
 }
 
@@ -23,8 +24,9 @@ async function ctShow (argv) {
   await assertSpaceIdProvided(argv)
 
   const contentTypeId = getId(argv)
-  const { cmaToken, activeSpaceId } = await getContext()
+  const { cmaToken, activeSpaceId, activeEnvironmentId } = await getContext()
   const spaceId = argv.spaceId || activeSpaceId
+  const environmentId = argv.environmentId || activeEnvironmentId
 
   const client = await createManagementClient({
     accessToken: cmaToken,
@@ -32,7 +34,8 @@ async function ctShow (argv) {
   })
 
   const space = await client.getSpace(spaceId)
-  const result = await space.getContentType(contentTypeId)
+  const environment = await space.getEnvironment(environmentId)
+  const result = await environment.getContentType(contentTypeId)
 
   const { sys, name, displayField, fields } = result
 


### PR DESCRIPTION
## Summary

Introduce the `environmentId` to the `get` command. 

## Description

Solves what describe in #65 