### PR TITLE
Config/lint test only changed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:e2e:update": "BABEL_ENV=test jest test/integration/cmds/** --verbose --updateSnapshot",
     "test:e2e:watch": "BABEL_ENV=test jest test/integration/cmds/** --verbose --watch",
     "test:simulate-ci": "trevor",
-    "precommit": "npm run lint",
+    "precommit": "lint-staged",
     "prepush": "npm run test:unit"
   },
   "devDependencies": {
@@ -57,6 +57,7 @@
     "http-proxy": "^1.17.0",
     "husky": "^0.14.3",
     "jest": "^23.4.2",
+    "lint-staged": "^7.2.2",
     "nixt": "^0.5.0",
     "node-zip": "^1.1.1",
     "nodemon": "^1.18.3",
@@ -142,5 +143,8 @@
     "assets": [
       "./node_modules/figlet/fonts/Standard.flf"
     ]
+  },
+  "lint-staged": {
+    "*.js": ["eslint --fix", "git add"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:e2e:watch": "BABEL_ENV=test jest test/integration/cmds/** --verbose --watch",
     "test:simulate-ci": "trevor",
     "precommit": "lint-staged",
-    "prepush": "npm run test:unit"
+    "prepush": "jest --changedSince master"
   },
   "devDependencies": {
     "app-root-path": "^2.1.0",


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

Small effort to save some time while committing.
* now use lint-staged for linting only staged files on `pre-commit` hook
* now use `jest --changedSince master` on `pre-push` hook, to attempt to only run tests affected by changes in code