### PR TITLE
fix(contentful-clients.js): send proxy object to CMA client

### DIFF
--- a/lib/utils/contentful-clients.js
+++ b/lib/utils/contentful-clients.js
@@ -1,14 +1,12 @@
 import { createClient } from 'contentful-management'
 import { version } from '../../package.json'
 import { getContext } from '../context'
-import { agentFromProxy } from './proxy'
 
 export async function createManagementClient (params) {
   params.application = `contentful.cli/${version}`
 
   const context = await getContext()
   const { proxy, host = 'api.contentful.com' } = context
-  const { httpsAgent } = agentFromProxy(proxy)
 
-  return createClient({ ...params, httpsAgent, host })
+  return createClient({ ...params, proxy, host })
 }


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary
Discovered a bug when implementing proxy to record/replay http requests in integration tests. Simply sending the `proxy` object instead of creating an `httpsAgent` instance fixes the problem. Wanted to discuss if this solution is viable.
