### PR TITLE
tests(unit): fix merge issues from tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:integration:watch": "BABEL_ENV=test jest test/integration/cmds/** --verbose --watch",
     "test:simulate-ci": "trevor",
     "precommit": "lint-staged",
-    "prepush": "jest --changedSince master"
+    "prepush": "BABEL_ENV=test jest --changedSince master test/unit/**"
   },
   "devDependencies": {
     "app-root-path": "^2.1.0",

--- a/test/unit/cmds/space_cmds/create.test.js
+++ b/test/unit/cmds/space_cmds/create.test.js
@@ -120,15 +120,10 @@ test('create space - accepts default locale', async () => {
     name: 'space name',
     defaultLocale: 'de-DE'
   }
-  emptyContext()
-  setContext({
-    cmaToken: 'mockedToken'
-  })
   const result = await spaceCreate(spaceData)
   expect(result).toBeTruthy()
-  expect(createManagementClientStub.calledOnce).toBe(true)
-  expect(fakeClient.createSpace.calledOnce).toBe(true)
-  expect(fakeClient.createSpace.args[0][0]).toEqual(spaceData)
-  expect(fakeClient.createSpace.args[0][1]).toBe(undefined)
-  expect(promptStub.notCalled).toBe(true)
+  expect(fakeClient.createSpace).toHaveBeenCalledTimes(1)
+  expect(fakeClient.createSpace.mock.calls[0][0]).toEqual(spaceData)
+  expect(fakeClient.createSpace.mock.calls[0][1]).toBe(undefined)
+  expect(inquirer.prompt).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
The jest mock pr broke some tests since i forgot to rebase on master.

This fixes it + runs the jest tests on push in the right context + unit tests only (for now)