### PR TITLE
fix(space/create): do not allow space creation without a name

### DIFF
--- a/lib/cmds/space_cmds/create.js
+++ b/lib/cmds/space_cmds/create.js
@@ -23,7 +23,8 @@ export const builder = (yargs) => {
     .option('name', {
       alias: 'n',
       describe: 'Name of the space to create',
-      demandOption: true
+      demandOption: true,
+      requiresArg: true
     })
     .option('management-token', {
       describe: 'Contentful management API token',


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

Fixes problem with space creation without a name described on #49 

## Description

I tried to fix this issue adding the `requiresArg` option to this command options, but I got a problem. Apparently yargs passes an `YError` instance to `.fail()` callback when this option validation fails, a different behavior compared to the `demandOption` validation, making follow code to run, and breaking the output message: https://github.com/contentful/contentful-cli/blob/70f9c6c446a5a305a3b46e495176996c9f4d9547/lib/cli.js#L31.

Is it ok to remove this error throwing from the `fail` callback? I could not understand the purpose of that.

## Motivation and Context

Fixes #49 
