### PR TITLE
update extension commands with cli option for access token

### DIFF
--- a/lib/cmds/extension_cmds/create.js
+++ b/lib/cmds/extension_cmds/create.js
@@ -18,6 +18,7 @@ export const builder = (yargs) => {
   return yargs
     .option('id', { type: 'string', describe: 'Extension id' })
     .option('name', { type: 'string', describe: 'Extension name' })
+    .option('management-token', { type: 'string', describe: 'Contentful management API token' })
     .option('space-id', { type: 'string', describe: 'Space id' })
     .option('environment-id', { type: 'string', describe: 'Environment id', default: 'master' })
     .option('field-types', { type: 'array', describe: 'Field types' })
@@ -55,7 +56,7 @@ export async function createExtension (argv) {
   const environmentId = argv.environmentId
 
   const client = await createManagementClient({
-    accessToken: cmaToken,
+    accessToken: argv.managementToken || cmaToken,
     feature: 'extension-create'
   })
 

--- a/lib/cmds/extension_cmds/delete.js
+++ b/lib/cmds/extension_cmds/delete.js
@@ -14,6 +14,7 @@ export const desc = 'Delete an extension'
 export const builder = (yargs) => {
   return yargs
     .option('id', { type: 'string', demand: true, describe: 'Extension id' })
+    .option('management-token', { type: 'string', describe: 'Contentful management API token' })
     .option('space-id', { type: 'string', describe: 'Space id' })
     .option('environment-id', { type: 'string', describe: 'Environment id', default: 'master' })
     .option('version', {
@@ -36,7 +37,7 @@ export async function deleteExtension (argv) {
   const environmentId = argv.environmentId
 
   const client = await createManagementClient({
-    accessToken: cmaToken,
+    accessToken: argv.managementToken || cmaToken,
     feature: 'extension-delete'
   })
 

--- a/lib/cmds/extension_cmds/get.js
+++ b/lib/cmds/extension_cmds/get.js
@@ -11,6 +11,7 @@ export const desc = 'Show an extension'
 export const builder = (yargs) => {
   return yargs
     .option('id', { type: 'string', demand: true, describe: 'Extension id' })
+    .option('management-token', { type: 'string', describe: 'Contentful management API token' })
     .option('space-id', { type: 'string', describe: 'Space id' })
     .option('environment-id', { type: 'string', describe: 'Environment id', default: 'master' })
     .epilog('Copyright 2018 Contentful, this is a BETA release')
@@ -25,7 +26,7 @@ async function getExtension (argv) {
   const environmentId = argv.environmentId
 
   const client = await createManagementClient({
-    accessToken: cmaToken,
+    accessToken: argv.managementToken || cmaToken,
     feature: 'extension-get'
   })
 

--- a/lib/cmds/extension_cmds/list.js
+++ b/lib/cmds/extension_cmds/list.js
@@ -13,6 +13,7 @@ export const desc = 'List all extensions'
 
 export const builder = (yargs) => {
   return yargs
+    .option('management-token', { type: 'string', describe: 'Contentful management API token' })
     .option('space-id', { type: 'string', describe: 'Space id' })
     .option('environment-id', { type: 'string', describe: 'Environment id', default: 'master' })
     .epilog('Copyright 2018 Contentful, this is a BETA release')
@@ -27,7 +28,7 @@ export async function listExtensions (argv) {
   const environmentId = argv.environmentId
 
   const client = await createManagementClient({
-    accessToken: cmaToken,
+    accessToken: argv.managementToken || cmaToken,
     feature: 'extension-list'
   })
 

--- a/lib/cmds/extension_cmds/update.js
+++ b/lib/cmds/extension_cmds/update.js
@@ -21,6 +21,7 @@ export const builder = (yargs) => {
   return yargs
     .option('id', { type: 'string', describe: 'Extension id' })
     .option('name', { type: 'string', describe: 'Extension name' })
+    .option('management-token', { type: 'string', describe: 'Contentful management API token' })
     .option('space-id', { type: 'string', describe: 'Space id' })
     .option('environment-id', { type: 'string', describe: 'Environment id', default: 'master' })
     .option('field-types', { type: 'array', describe: 'Field types' })
@@ -66,7 +67,7 @@ export async function updateExtension (argv) {
   const environmentId = argv.environmentId
 
   const client = await createManagementClient({
-    accessToken: cmaToken,
+    accessToken: argv.managementToken || cmaToken,
     feature: 'extension-update'
   })
 


### PR DESCRIPTION
## Description
From issue https://github.com/contentful/contentful-cli/issues/96 this allows passing the CMA token via cli for extension commands

```
contentful extension list --space-id $CONTENTFUL_SPACE --management-token $CONTENTFUL_CMA_TOKEN
```

## Expected Behavior
If the user does not perform `contentful login`, extension commands can be used by passing a `--management-Token` option, ex.

```
contentful extension list --space-id $CONTENTFUL_SPACE --management-token $CONTENTFUL_CMA_TOKEN
```

## Actual Behavior
Command actually throws because the management token for `extension_cmds` commands is not parsed and applied the same way that is for `space_cmds`

```
contentful extension list --space-id $CONTENTFUL_SPACE --management-token $CONTENTFUL_CMA_TOKEN

🚨  Error: Expected parameter accessToken
│ TypeError: Expected parameter accessToken                                                                                           │
│      at createClient                                                                                                                │
│ (/.config/yarn/global/node_modules/contentful-management/dist/contentful-management.node.js:6894:11)             │
│      at createManagementClient                                                                                                      │
│ (/.config/yarn/global/node_modules/contentful-cli/dist/utils/contentful-clients.js:26:49)                        │
│      at <anonymous> 
```

## Possible Solution
Add the `argv.token` parsing / argument to where `createManagementClient` is called in the extensions commands. I would also be happy to put forth a PR for this

ex.

```js
  const client = await createManagementClient({
    accessToken: argv.managementToken || cmaToken,
    feature: 'extension-list'
  })
```

## Steps to Reproduce

<!--
Provide a link to a live example, or an unambiguous set of steps to reproduce
this bug. If relevant, provide code that demonstrates the problem, keeping it as
simple and free of external dependencies as possible.
-->
1. Do NOT run contentful login
2. Generate a CMA personal token
3. Add it to your environment `export CONTENTFUL_CMA_TOKEN=<your_token>`
4. Run an `extension` command `contentful extension list --space-id $CONTENTFUL_SPACE --management-token $CONTENTFUL_CMA_TOKEN`

## Context
Deploy extension in CI with encrypted CMA token

## Environment

-   **Language Version**: Node@8.10.0
-   **Package Manager Version**: yarn@1.12.1
-   **Browser Version**: NA
-   **Operating System**: MacOS@10.12.6
-   **Package Version**: 0.16.1
