### PR TITLE
change guide config filenames from `.contentful.json` to `contentful.json`

### DIFF
--- a/lib/cmds/guide.js
+++ b/lib/cmds/guide.js
@@ -28,11 +28,11 @@ const guides = {
     repository: 'contentful/blog-in-5-minutes',
     seed: 'blog',
     setupConfig: async ({cmaToken, cdaToken, spaceId, installationDirectory}) => {
-      const config = await bfj.read(join(installationDirectory, '.contentful.sample.json'))
+      const config = await bfj.read(join(installationDirectory, 'contentful.sample.json'))
       config.CTF_CDA_ACCESS_TOKEN = cdaToken
       config.CTF_CMA_ACCESS_TOKEN = cmaToken
       config.CTF_SPACE_ID = spaceId
-      return bfj.write(join(installationDirectory, '.contentful.json'), config, {
+      return bfj.write(join(installationDirectory, 'contentful.json'), config, {
         space: 2
       })
     },
@@ -47,10 +47,10 @@ const guides = {
     repository: 'contentful/starter-gatsby-blog',
     seed: 'blog',
     setupConfig: async ({cdaToken, spaceId, installationDirectory}) => {
-      const config = await bfj.read(join(installationDirectory, '.contentful.json.sample'))
+      const config = await bfj.read(join(installationDirectory, 'contentful.json.sample'))
       config.spaceId = spaceId
       config.accessToken = cdaToken
-      return bfj.write(join(installationDirectory, '.contentful.json'), config, {
+      return bfj.write(join(installationDirectory, 'contentful.json'), config, {
         space: 2
       })
     },


### PR DESCRIPTION
beginner programmers and non technical people have given feedback that they can't find the guide config files `.contentful.json` or `.contentful.sample.json` and we found out this is largely due to macOS' default behavior of hiding files that start with a period. This change will clarify the setup and make it easier to find and change the configuration for beginners.

<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

- [x] Implemented feature
- [ ] Feature with pending implementation

## Screenshots (if appropriate):
