### PR TITLE
fix(generate migration): add management-token

### DIFF
--- a/lib/cmds/space_cmds/generate_cmds/migration.js
+++ b/lib/cmds/space_cmds/generate_cmds/migration.js
@@ -19,6 +19,11 @@ export const desc = 'Generate a migration file for your content model or a speci
 export const builder = (yargs) => {
   return yargs
     .usage('Usage: contentful space generate migration')
+    .option('management-token', {
+      describe: 'Content management API token',
+      alias: 't',
+      type: 'string'
+    })
     .option('space-id', {
       describe: 'ID of the space the content model will belong to',
       alias: 's',
@@ -270,13 +275,14 @@ export async function generateMigration (argv) {
 
   const { cmaToken, activeSpaceId, activeEnvironmentId } = await getContext()
   const spaceId = argv.spaceId || activeSpaceId
+  const managementToken = argv.managementToken || cmaToken
   const environmentId = argv.environmentId || activeEnvironmentId
   const contentTypeId = argv.contentTypeId
 
   const filename = argv.filename || generateFileName(spaceId, environmentId, contentTypeId)
 
   const environment = await getEnvironment(
-    cmaToken,
+    managementToken,
     spaceId,
     environmentId
   )


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

Add option to generate migration command to pass management token.

## Description

The generate migration command does not have an option to pass in the management token; and thus exhibits the same error as seen in the environment command described in #110

