### PR TITLE
fix(extensions): Make fieldTypes property optional

### DIFF
--- a/docs/extension/create/README.md
+++ b/docs/extension/create/README.md
@@ -13,7 +13,7 @@ Options:
   --space-id                 Space ID                   [string] [required]
   --environment-id'          Environment id             [string] [default:master]
 
-  --field-types              Field types                 [array] [required]
+  --field-types              Field types                            [array]
   --descriptor               Path of descriptor file               [string]
   --src                      Src                                   [string]
   --srcdoc                   Path of srcdoc file                   [string]

--- a/docs/extension/update/README.md
+++ b/docs/extension/update/README.md
@@ -12,7 +12,7 @@ Options:
   --name                     Name                       [string] [required]
   --space-id                 Space ID                   [string] [required]
   --environment-id          Environment id             [string] [default:master]
-  --field-types              Field types                 [array] [required]
+  --field-types              Field types                            [array]
   --descriptor               Path of descriptor file               [string]
   --src                      Src                                   [string]
   --srcdoc                   Path of srcdoc file                   [string]

--- a/lib/cmds/extension_cmds/create.js
+++ b/lib/cmds/extension_cmds/create.js
@@ -21,7 +21,7 @@ export const builder = (yargs) => {
     .option('management-token', { type: 'string', describe: 'Contentful management API token' })
     .option('space-id', { type: 'string', describe: 'Space id' })
     .option('environment-id', { type: 'string', describe: 'Environment id', default: 'master' })
-    .option('field-types', { type: 'array', describe: 'Field types' })
+    .option('field-types', { type: 'array', describe: 'Field types', default: undefined })
     .option('descriptor', { type: 'string', describe: 'Path to an extension descriptor file' })
     .option('src', { type: 'string', describe: 'URL to extension bundle' })
     .option('srcdoc', { type: 'string', describe: 'Path to extension bundle' })

--- a/lib/cmds/extension_cmds/update.js
+++ b/lib/cmds/extension_cmds/update.js
@@ -24,7 +24,7 @@ export const builder = (yargs) => {
     .option('management-token', { type: 'string', describe: 'Contentful management API token' })
     .option('space-id', { type: 'string', describe: 'Space id' })
     .option('environment-id', { type: 'string', describe: 'Environment id', default: 'master' })
-    .option('field-types', { type: 'array', describe: 'Field types' })
+    .option('field-types', { type: 'array', describe: 'Field types', default: undefined })
     .option('descriptor', { type: 'string', describe: 'Path to an extension descriptor file' })
     .option('src', { type: 'string', describe: 'URL to extension bundle' })
     .option('srcdoc', { type: 'string', describe: 'Path to extension bundle' })

--- a/lib/cmds/extension_cmds/utils/assertions.js
+++ b/lib/cmds/extension_cmds/utils/assertions.js
@@ -46,6 +46,6 @@ export async function assertExtensionValuesProvided (data, action) {
   if (action === 'update') {
     await assertHasRequiredProperties(data, ['id'])
   }
-  await assertHasRequiredProperties(data.extension, ['name', 'fieldTypes'])
+  await assertHasRequiredProperties(data.extension, ['name'])
   await assertHasOneProperty(data.extension, ['src', 'srcdoc'])
 }

--- a/lib/cmds/extension_cmds/utils/log-as-table.js
+++ b/lib/cmds/extension_cmds/utils/log-as-table.js
@@ -1,5 +1,5 @@
 import Table from 'cli-table3'
-import { get } from 'lodash'
+import { get, isArray } from 'lodash'
 
 import { getDisplayName } from './convert-field-type'
 import { log } from '../../../utils/log'
@@ -11,10 +11,12 @@ export function logExtension ({sys, extension, parameters}) {
 
   table.push(['ID', sys.id])
   table.push(['Name', extension.name])
-  table.push([
-    'Field types',
-    extension.fieldTypes.map(getDisplayName).join(', ')
-  ])
+  if (isArray(extension.fieldTypes)) {
+    table.push([
+      'Field types',
+      extension.fieldTypes.map(getDisplayName).join(', ')
+    ])
+  }
   table.push(['Src', extension.src || '[uses srcdoc]'])
   table.push(['Version', sys.version])
 

--- a/test/integration/cmds/extension/create.test.js
+++ b/test/integration/cmds/extension/create.test.js
@@ -61,7 +61,7 @@ test('should exit 1 everything except space id is given', done => {
     .run(`extension create --space-id ${space.sys.id}`)
     .code(1)
     .expect((result) => {
-      const regex = /Missing required properties:\s+name, field-types/
+      const regex = /Missing required properties:\s+name/
       expect(result.stderr.trim()).toMatch(regex)
     })
     .end(done)

--- a/test/integration/cmds/extension/update.test.js
+++ b/test/integration/cmds/extension/update.test.js
@@ -47,7 +47,7 @@ test('should exit 1 when only id is given', done => {
     .run('extension update --space-id some-id --id sample-extension')
     .code(1)
     .expect((result) => {
-      const regex = /Missing required properties:\s+name, field-types/
+      const regex = /Missing required properties:\s+name/
       expect(result.stderr.trim()).toMatch(regex)
     })
     .end(done)

--- a/test/unit/cmds/extension_cmds/__snapshots__/create.test.js.snap
+++ b/test/unit/cmds/extension_cmds/__snapshots__/create.test.js.snap
@@ -6,6 +6,4 @@ exports[`Throws error if both src and srcdoc are at the same time 1`] = `"Must c
 
 exports[`Throws error if both src and srcdoc are not provided 1`] = `"Must contain exactly one of: src, srcdoc"`;
 
-exports[`Throws error if field-types is missing 1`] = `"Missing required properties: field-types"`;
-
 exports[`Throws error if name is missing 1`] = `"Missing required properties: name"`;

--- a/test/unit/cmds/extension_cmds/__snapshots__/update.test.js.snap
+++ b/test/unit/cmds/extension_cmds/__snapshots__/update.test.js.snap
@@ -2,8 +2,6 @@
 
 exports[`Throws error if --version and --force are missing 1`] = `"Please provide current version or use the --force flag"`;
 
-exports[`Throws error if field-types is missing 1`] = `"Missing required properties: field-types"`;
-
 exports[`Throws error if id is missing 1`] = `"Missing required properties: id"`;
 
 exports[`Throws error if name is missing 1`] = `"Missing required properties: name"`;

--- a/test/unit/cmds/extension_cmds/create.test.js
+++ b/test/unit/cmds/extension_cmds/create.test.js
@@ -53,12 +53,6 @@ test('Throws error if name is missing', async () => {
   ).rejects.toThrowErrorMatchingSnapshot()
 })
 
-test('Throws error if field-types is missing', async () => {
-  await expect(
-    createExtension({ spaceId: 'space', environmentId: 'master', name: 'Widget', src: 'https://awesome.extension' })
-  ).rejects.toThrowErrorMatchingSnapshot()
-})
-
 test('Throws error if both src and srcdoc are not provided', async () => {
   await expect(
     createExtension({ spaceId: 'space', environmentId: 'master', name: 'Widget', fieldTypes: ['Symbol'] })
@@ -88,6 +82,23 @@ test('Throws an error if installation parameters cannot be parsed', async () => 
       installationParameters: '{"test": lol}'
     })
   ).rejects.toThrowErrorMatchingSnapshot()
+})
+
+test('Creates extension if field-types is missing', async () => {
+  await createExtension({
+    spaceId: 'space',
+    name: 'Widget',
+    src: 'https://awesome.extension'
+  })
+
+  expect(createUiExtensionStub).toHaveBeenCalledWith({
+    extension: {
+      name: 'Widget',
+      src: 'https://awesome.extension'
+    }
+  })
+  expect(success).toHaveBeenCalledWith(`${successEmoji} Successfully created extension:\n`)
+  expect(log).toHaveBeenCalledTimes(1)
 })
 
 test('Creates extension from command line arguments', async () => {

--- a/test/unit/cmds/extension_cmds/update.test.js
+++ b/test/unit/cmds/extension_cmds/update.test.js
@@ -62,12 +62,6 @@ test('Throws error if name is missing', async () => {
   ).rejects.toThrowErrorMatchingSnapshot()
 })
 
-test('Throws error if field-types is missing', async () => {
-  await expect(
-    updateExtension({ id: '123', spaceId: 'space', name: 'Widget', src: 'https://awesome.extension', force: true })
-  ).rejects.toThrowErrorMatchingSnapshot()
-})
-
 test('Throws error if --version and --force are missing', async () => {
   await expect(
     updateExtension({ spaceId: 'space', id: '123', name: 'Widget', fieldTypes: ['Symbol'], src: 'https://awesome.extension' })
@@ -88,7 +82,6 @@ test(
       force: true,
       spaceId: 'space',
       name: 'Widget',
-      fieldTypes: ['Symbol'],
       src: 'https://new.url'
     })
 


### PR DESCRIPTION
## Summary

`fieldsTypes` became optional after the release of Custom Sidebar feature. This PR makes this field optional in CLI.

## Motivation and Context

Sync CMA validation with cli validation 
