### PR TITLE
fix(space export) Use previously stored environment-id

### DIFF
--- a/lib/cmds/space_cmds/export.js
+++ b/lib/cmds/space_cmds/export.js
@@ -19,8 +19,7 @@ export const builder = function (yargs) {
     })
     .option('environment-id', {
       describe: 'ID of Environment with source data',
-      type: 'string',
-      default: 'master'
+      type: 'string'
     })
     .option('management-token', {
       describe: 'Contentful management API token',
@@ -112,13 +111,14 @@ export const exportSpace = async (argv) => {
   await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
 
-  const { cmaToken, activeSpaceId, proxy, rawProxy, host = 'api.contentful.com' } = await getContext()
+  const { cmaToken, activeSpaceId, activeEnvironmentId, proxy, rawProxy, host = 'api.contentful.com' } = await getContext()
   const spaceId = argv.spaceId || activeSpaceId
+  const environmentId = argv.environmentId || activeEnvironmentId
   const managementToken = argv.managementToken || cmaToken
   const managementApplication = `contentful.cli/${version}`
   const managementFeature = argv.feature || `space-export`
 
-  const options = { ...argv, spaceId, managementApplication, managementFeature, managementToken, host }
+  const options = { ...argv, spaceId, environmentId, managementApplication, managementFeature, managementToken, host }
 
   if (proxy) {
     // contentful-import and contentful-export


### PR DESCRIPTION

## Summary

Fixes Isssue 117:
If an environment-id is stored previously using ```contentful space environment use```, the export function does not use it.

## Description

The bug was due to the environment-id command line argument having a default value of "master". Removed the default and replaced it with a check against the context, just like for store-id.

## Motivation and Context

[Issue 117](https://github.com/contentful/contentful-cli/issues/117)

