### PR TITLE
fix(extensions): Fix incorrect default value for fieldTypes

### DIFF
--- a/lib/cmds/extension_cmds/create.js
+++ b/lib/cmds/extension_cmds/create.js
@@ -21,7 +21,7 @@ export const builder = (yargs) => {
     .option('management-token', { type: 'string', describe: 'Contentful management API token' })
     .option('space-id', { type: 'string', describe: 'Space id' })
     .option('environment-id', { type: 'string', describe: 'Environment id', default: 'master' })
-    .option('field-types', { type: 'array', describe: 'Field types', default: undefined })
+    .option('field-types', { type: 'array', describe: 'Field types' })
     .option('descriptor', { type: 'string', describe: 'Path to an extension descriptor file' })
     .option('src', { type: 'string', describe: 'URL to extension bundle' })
     .option('srcdoc', { type: 'string', describe: 'Path to extension bundle' })

--- a/lib/cmds/extension_cmds/update.js
+++ b/lib/cmds/extension_cmds/update.js
@@ -24,7 +24,7 @@ export const builder = (yargs) => {
     .option('management-token', { type: 'string', describe: 'Contentful management API token' })
     .option('space-id', { type: 'string', describe: 'Space id' })
     .option('environment-id', { type: 'string', describe: 'Environment id', default: 'master' })
-    .option('field-types', { type: 'array', describe: 'Field types', default: undefined })
+    .option('field-types', { type: 'array', describe: 'Field types' })
     .option('descriptor', { type: 'string', describe: 'Path to an extension descriptor file' })
     .option('src', { type: 'string', describe: 'URL to extension bundle' })
     .option('srcdoc', { type: 'string', describe: 'Path to extension bundle' })


### PR DESCRIPTION
## Summary

Fixes a bug in `contentful extension create` and `contentful extension update` introduced in v0.19.0

## Learnings

Don't use default values for `type: array`