### PR TITLE
Address deprecated function warning when listing content types

### DIFF
--- a/docs/content-type/list/README.md
+++ b/docs/content-type/list/README.md
@@ -8,18 +8,20 @@ Prints the Content Types in a space
 Usage: contentful content-type list [options]
 
 Options:
-  --space-id  Space id                                                  [string]
+  --space-id, -s            Space id                                                  [string]
+  --management-token, -mt   Management token                                          [string]
+  --environment-id, -e      Environment id                                            [string]
 ```
 
 ### Example
 
 ```shell
-contentful content-type list --space-id xxx
+contentful content-type list --space-id xxx -e master
+
+Environment: "master"
 ┌───────────────────┬────────────────────────┐
 │ Content Type Name │ Content Type ID        │
 ├───────────────────┼────────────────────────┤
 │ Test              │ test                   │
 └───────────────────┴────────────────────────┘
 ```
-
-

--- a/lib/cmds/content-type_cmds/list.js
+++ b/lib/cmds/content-type_cmds/list.js
@@ -47,7 +47,9 @@ async function ctList (argv) {
 
   const space = await client.getSpace(spaceId)
   const environment = await space.getEnvironment(environmentId)
+
   log(highlightStyle(`Environment: "${environmentId}"`))
+
   const result = await paginate({
     client: environment,
     method: 'getContentTypes',

--- a/lib/cmds/content-type_cmds/list.js
+++ b/lib/cmds/content-type_cmds/list.js
@@ -6,6 +6,7 @@ import { assertLoggedIn, assertSpaceIdProvided } from '../../utils/assertions'
 import { handleAsyncError as handle } from '../../utils/async'
 import { log } from '../../utils/log'
 import paginate from '../../utils/pagination'
+import { highlightStyle } from '../../utils/styles'
 
 export const command = 'list'
 
@@ -17,6 +18,11 @@ export const builder = (yargs) => {
   return yargs
     .option('space-id', { alias: 's', type: 'string', describe: 'Space id' })
     .option('management-token', { alias: 'mt', type: 'string', describe: 'Contentful management API token' })
+    .option('environment-id', {
+      alias: 'e',
+      type: 'string',
+      describe: 'Environment ID you want to interact with. Defaults to the current active environment.'
+    })
     .epilog('Copyright 2018 Contentful, this is a BETA release')
 }
 
@@ -24,9 +30,10 @@ async function ctList (argv) {
   await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
 
-  const { cmaToken, activeSpaceId } = await getContext()
+  const { cmaToken, activeSpaceId, activeEnvironmentId } = await getContext()
   const managementToken = argv.managementToken || cmaToken
   const spaceId = argv.spaceId || activeSpaceId
+  const environmentId = argv.environmentId || activeEnvironmentId
 
   const client = await createManagementClient({
     accessToken: managementToken,
@@ -34,8 +41,10 @@ async function ctList (argv) {
   })
 
   const space = await client.getSpace(spaceId)
+  const environment = await space.getEnvironment(environmentId)
+  log(highlightStyle(`Environment: "${environmentId}"`))
   const result = await paginate({
-    client: space,
+    client: environment,
     method: 'getContentTypes',
     query: {
       order: 'name,sys.id'

--- a/lib/cmds/content-type_cmds/list.js
+++ b/lib/cmds/content-type_cmds/list.js
@@ -14,14 +14,19 @@ export const desc = 'List your content types'
 
 export const aliases = ['ls']
 
-export const builder = (yargs) => {
+export const builder = yargs => {
   return yargs
     .option('space-id', { alias: 's', type: 'string', describe: 'Space id' })
-    .option('management-token', { alias: 'mt', type: 'string', describe: 'Contentful management API token' })
+    .option('management-token', {
+      alias: 'mt',
+      type: 'string',
+      describe: 'Contentful management API token'
+    })
     .option('environment-id', {
       alias: 'e',
       type: 'string',
-      describe: 'Environment ID you want to interact with. Defaults to the current active environment.'
+      describe:
+        'Environment ID you want to interact with. Defaults to the current active environment.'
     })
     .epilog('Copyright 2018 Contentful, this is a BETA release')
 }
@@ -33,7 +38,7 @@ async function ctList (argv) {
   const { cmaToken, activeSpaceId, activeEnvironmentId } = await getContext()
   const managementToken = argv.managementToken || cmaToken
   const spaceId = argv.spaceId || activeSpaceId
-  const environmentId = argv.environmentId || activeEnvironmentId
+  const environmentId = argv.environmentId || activeEnvironmentId || 'master'
 
   const client = await createManagementClient({
     accessToken: managementToken,
@@ -55,7 +60,7 @@ async function ctList (argv) {
     head: ['Content Type Name', 'Content Type ID']
   })
 
-  result.items.forEach((contentType) => {
+  result.items.forEach(contentType => {
     table.push([contentType.name, contentType.sys.id])
   })
 

--- a/lib/cmds/space_cmds/environment_cmds/list.js
+++ b/lib/cmds/space_cmds/environment_cmds/list.js
@@ -6,6 +6,7 @@ import { handleAsyncError as handle } from '../../../utils/async'
 import { createManagementClient } from '../../../utils/contentful-clients'
 import { log } from '../../../utils/log'
 import paginate from '../../../utils/pagination'
+import { highlightStyle } from '../../../utils/styles'
 
 export const command = 'list'
 
@@ -37,7 +38,7 @@ export async function environmentList (argv) {
   await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
 
-  const { cmaToken, activeSpaceId } = await getContext()
+  const { cmaToken, activeSpaceId, activeEnvironmentId } = await getContext()
   const spaceId = argv.spaceId || activeSpaceId
   const managementToken = argv.managementToken || cmaToken
 
@@ -57,7 +58,19 @@ export async function environmentList (argv) {
   })
 
   environments.forEach((environment) => {
-    table.push([environment.name, environment.sys.id, environment.sys.status.sys.id])
+    if (activeEnvironmentId === environment.sys.id) {
+      table.push([
+        highlightStyle(`${environment.name} [active]`),
+        highlightStyle(environment.sys.id),
+        highlightStyle(environment.sys.status.sys.id)
+      ])
+    } else {
+      table.push([
+        environment.name,
+        environment.sys.id,
+        environment.sys.status.sys.id
+      ])
+    }
   })
 
   log(table.toString())

--- a/test/unit/cmds/content-type_cmds/list.test.js
+++ b/test/unit/cmds/content-type_cmds/list.test.js
@@ -1,0 +1,138 @@
+import { handler } from '../../../../lib/cmds/content-type_cmds/list'
+import { getContext } from '../../../../lib/context'
+import { log } from '../../../../lib/utils/log'
+import { createManagementClient } from '../../../../lib/utils/contentful-clients'
+
+jest.mock('../../../../lib/context')
+jest.mock('../../../../lib/utils/log')
+jest.mock('../../../../lib/utils/contentful-clients')
+
+const mockContentTypes = [
+  {
+    name: 'content type name',
+    sys: {
+      id: 'mockedMasterCT',
+      environment: {
+        sys: {
+          id: 'master'
+        }
+      }
+    }
+  },
+  {
+    name: 'content type name',
+    sys: {
+      id: 'mockedDevelopCT',
+      environment: {
+        sys: {
+          id: 'develop'
+        }
+      }
+    }
+  },
+  {
+    name: 'content type name',
+    sys: {
+      id: 'mockedTestCT',
+      environment: {
+        sys: {
+          id: 'test'
+        }
+      }
+    }
+  }
+]
+
+const getContentTypesSub = jest.fn().mockResolvedValue({
+  items: mockContentTypes
+})
+
+const fakeClient = {
+  getSpace: async () => ({
+    getEnvironment: async () => ({
+      getContentTypes: getContentTypesSub
+    })
+  })
+}
+createManagementClient.mockResolvedValue(fakeClient)
+
+getContext.mockResolvedValue({
+  cmaToken: 'mockedToken',
+  activeSpaceId: 'someSpaceId'
+})
+
+afterEach(() => {
+  createManagementClient.mockClear()
+  getContentTypesSub.mockClear()
+  log.mockClear()
+})
+
+test('List content types from default environment, "master"', async () => {
+  await handler({})
+
+  expect(createManagementClient).toHaveBeenCalledTimes(1)
+  expect(getContentTypesSub).toHaveBeenCalledTimes(1)
+
+  expect(log.mock.calls[0][0]).toContain(
+    mockContentTypes[0].sys.environment.sys.id
+  )
+  expect(log.mock.calls[0][0]).not.toContain(
+    mockContentTypes[1].sys.environment.sys.id
+  )
+  expect(log.mock.calls[0][0]).not.toContain(
+    mockContentTypes[2].sys.environment.sys.id
+  )
+
+  expect(log.mock.calls[1][0]).toContain(mockContentTypes[0].name)
+  expect(log.mock.calls[1][0]).toContain(mockContentTypes[0].sys.id)
+})
+
+test('List content types based on active environment if available', async () => {
+  getContext.mockResolvedValue({
+    cmaToken: 'mockedToken',
+    activeSpaceId: 'someSpaceId',
+    activeEnvironmentId: 'develop'
+  })
+
+  await handler({})
+
+  expect(createManagementClient).toHaveBeenCalledTimes(1)
+  expect(getContentTypesSub).toHaveBeenCalledTimes(1)
+
+  expect(log.mock.calls[0][0]).not.toContain(
+    mockContentTypes[0].sys.environment.sys.id
+  )
+  expect(log.mock.calls[0][0]).toContain(
+    mockContentTypes[1].sys.environment.sys.id
+  )
+  expect(log.mock.calls[0][0]).not.toContain(
+    mockContentTypes[2].sys.environment.sys.id
+  )
+
+  expect(log.mock.calls[1][0]).toContain(mockContentTypes[1].name)
+  expect(log.mock.calls[1][0]).toContain(mockContentTypes[1].sys.id)
+})
+
+test('List content types based on environment passed if --environment-id option is used', async () => {
+  const stubArgv = {
+    environmentId: 'test'
+  }
+
+  await handler(stubArgv)
+
+  expect(createManagementClient).toHaveBeenCalledTimes(1)
+  expect(getContentTypesSub).toHaveBeenCalledTimes(1)
+
+  expect(log.mock.calls[0][0]).not.toContain(
+    mockContentTypes[0].sys.environment.sys.id
+  )
+  expect(log.mock.calls[0][0]).not.toContain(
+    mockContentTypes[1].sys.environment.sys.id
+  )
+  expect(log.mock.calls[0][0]).toContain(
+    mockContentTypes[2].sys.environment.sys.id
+  )
+
+  expect(log.mock.calls[1][0]).toContain(mockContentTypes[2].name)
+  expect(log.mock.calls[1][0]).toContain(mockContentTypes[2].sys.id)
+})


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary
Be more Environment aware.

<!-- Give a short summary of what your PR is introducing/fixing. -->

## Description
- Get content types via the environment vs space
- Add new option, environment id, to specify the environment when listing content types
- Update content type list cmd documentation with new options
<!-- Describe your changes in detail -->

## Motivation and Context
- Given the environment driven context, certain methods would only be available by an environment object hence deprecation warnings
- Valuable to have context on which environment is active and which one is currently on when listing content types.
- Nice to have, being able to list content types from a specific environment without having to switch to that environment.

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->
