### PR TITLE
Add --quiet option for migrations

### DIFF
--- a/lib/cmds/space_cmds/migration.js
+++ b/lib/cmds/space_cmds/migration.js
@@ -44,6 +44,12 @@ export const builder = (yargs) => {
       describe: 'Skips any confirmation before applying the migration script',
       default: false
     })
+    .option('quiet', {
+      alias: 'q',
+      boolean: false,
+      describe: 'Reduce verbosity of information for the execution',
+      default: false
+    })
     .help('h')
     .alias('h', 'help')
     .example('contentful migration', '--space-id abcedef my-migration.js')

--- a/package-lock.json
+++ b/package-lock.json
@@ -2536,9 +2536,9 @@
       }
     },
     "contentful-migration": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/contentful-migration/-/contentful-migration-0.16.6.tgz",
-      "integrity": "sha512-w4iqTtCKUyXQyFDXUuLrxiPGMOhHV4WYqgiWkWP6awglzal8eGENBe22LPuhUJ8ZPUypxYiCEGl+QOUxEyfCKg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/contentful-migration/-/contentful-migration-0.17.0.tgz",
+      "integrity": "sha512-b43xvNnPaximbO5SdBGUeLU1yZPMeE0KlX6NUQ9uV8cUbLnj0DD8EzhySB9ywzHc7ZKJozYt3sskeL+azGIf7A==",
       "requires": {
         "bluebird": "^3.5.0",
         "callsites": "^2.0.0",
@@ -2623,12 +2623,12 @@
           }
         },
         "contentful-management": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-5.6.0.tgz",
-          "integrity": "sha512-keBXPHSVxtYRwcnEFreCVfDGD5XZGD/pCkS+1UybvFmaxnXppTfnlvEUW8MoMg4GunN6BELl9ButBfoUfhqaYg==",
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-5.7.0.tgz",
+          "integrity": "sha512-hXsu9k/nMkSI2OV0zCyVB9thFcRiz2wYesKbMbFlINuAKUbVeOc4DZJQ5/anrb7X4Bin867VHZ3XtvX0+oIcPg==",
           "requires": {
             "@contentful/axios": "^0.18.0",
-            "contentful-sdk-core": "^6.2.1",
+            "contentful-sdk-core": "^6.3.0",
             "lodash": "^4.17.11"
           },
           "dependencies": {
@@ -2640,9 +2640,9 @@
           }
         },
         "contentful-sdk-core": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.2.1.tgz",
-          "integrity": "sha512-fCZ2GNpsoWyroZ/j86JUHnGWmjCMcGGNqD4ll6fepR3EFN9YGySLLJzkQiXEDGap5+vmwcURyac8MPl6jP2FsQ==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.3.0.tgz",
+          "integrity": "sha512-PbZn4OZO/iBk4OjEHir6pX6p4c/q3lwQ3M9pLeibaoiwT8fd3JRfeL4tL0L8M2d9mS8y3g2FRDWmBAI2+0Xlcg==",
           "requires": {
             "lodash": "^4.17.10",
             "qs": "^6.5.2"
@@ -5185,7 +5185,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5209,13 +5210,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5232,19 +5235,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5375,7 +5381,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5389,6 +5396,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5405,6 +5413,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5413,13 +5422,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5440,6 +5451,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5528,7 +5540,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5542,6 +5555,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5637,7 +5651,8 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5679,6 +5694,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5700,6 +5716,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5748,13 +5765,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -13578,6 +13597,7 @@
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -14664,7 +14684,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "contentful-export": "^7.3.0",
     "contentful-import": "^7.3.0",
     "contentful-management": "^6.1.0-beta2",
-    "contentful-migration": "^0.16.3",
+    "contentful-migration": "^0.17.0",
     "emojic": "^1.1.11",
     "execa": "^0.10.0",
     "figlet": "^1.2.0",


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

<!-- Give a short summary of what your PR is introducing/fixing. -->
Allow for migrations to happen with a quiet mode

## Description

<!-- Describe your changes in detail -->
- Add option `--quiet, -q` to the usage params

## Motivation and Context
The [Contentful Migration](https://github.com/contentful/contentful-migration) package now supports a quiet mode. Hence, Contentful Cli needs to be updated accordingly.

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

-   [x] Implemented feature

## Screenshots (if appropriate):
<img width="440" alt="Screen Shot 2019-03-19 at 11 42 42" src="https://user-images.githubusercontent.com/11521847/54600092-4d7c5d80-4a3c-11e9-8def-75808123fd57.png">
