### PR TITLE
feat(config): change config look up order

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -11,10 +11,8 @@ let configPath
 export async function getConfigPath () {
   const contentfulrc = '.contentfulrc.json'
   const defaultPath = resolve(homedir(), contentfulrc)
-  if (!configPath) {
-    const nestedConfigPath = await findUp(contentfulrc)
-    configPath = nestedConfigPath || defaultPath
-  }
+  const nestedConfigPath = await findUp(contentfulrc)
+  configPath = nestedConfigPath || defaultPath
   return configPath
 }
 


### PR DESCRIPTION
## Summary

This PR changes `.contentfulrc.json` look up order. 

## Description

*Current behavior*: `.contentfulrc.json` located in `home` folder trumps config located in `process.cwd()`

*New behavior*: script tries to find `.contentfulrc.json` in `process.cwd()` (and then looks one folder up in a tree, recursively). if there's no `.contentfulrc.json` in a tree, then `home` folder is used.

## Motivation and Context

It's convenient to collocate config with a project you're currently working on and be able to jump between projects without a need to change configuration in global configuration file.

Current behavior complicates the flow for extensions development using [create-contentful-extension](https://github.com/contentful/create-contentful-extension).

