### PR TITLE
fix(extensions): all extensions cmd should respect activeEnviromentId

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+fooSpace-fooEnv-*
 
 # Runtime data
 pids

--- a/lib/cmds/extension_cmds/create.js
+++ b/lib/cmds/extension_cmds/create.js
@@ -20,7 +20,7 @@ export const builder = (yargs) => {
     .option('name', { type: 'string', describe: 'Extension name' })
     .option('management-token', { alias: 'mt', type: 'string', describe: 'Contentful management API token' })
     .option('space-id', { type: 'string', describe: 'Space id' })
-    .option('environment-id', { type: 'string', describe: 'Environment id', default: 'master' })
+    .option('environment-id', { type: 'string', describe: 'Environment id' })
     .option('field-types', { type: 'array', describe: 'Field types' })
     .option('descriptor', { type: 'string', describe: 'Path to an extension descriptor file' })
     .option('src', { type: 'string', describe: 'URL to extension bundle' })
@@ -65,9 +65,9 @@ export async function createExtensionHandler (argv) {
     await readSrcDocFile(data.extension)
   }
 
-  const { cmaToken, activeSpaceId } = await getContext()
+  const { cmaToken, activeSpaceId, activeEnvironmentId } = await getContext()
   const spaceId = argv.spaceId || activeSpaceId
-  const environmentId = argv.environmentId
+  const environmentId = argv.environmentId || activeEnvironmentId || 'master'
 
   const client = await createManagementClient({
     accessToken: argv.managementToken || cmaToken,
@@ -81,7 +81,7 @@ export async function createExtensionHandler (argv) {
 
   success(`${successEmoji} Successfully created extension:\n`)
 
-  logExtension(extension, spaceId)
+  logExtension(extension, spaceId, environmentId)
 }
 
 export const handler = handle(createExtensionHandler)

--- a/lib/cmds/extension_cmds/delete.js
+++ b/lib/cmds/extension_cmds/delete.js
@@ -16,7 +16,7 @@ export const builder = (yargs) => {
     .option('id', { type: 'string', demand: true, describe: 'Extension id' })
     .option('management-token', { alias: 'mt', type: 'string', describe: 'Contentful management API token' })
     .option('space-id', { type: 'string', describe: 'Space id' })
-    .option('environment-id', { type: 'string', describe: 'Environment id', default: 'master' })
+    .option('environment-id', { type: 'string', describe: 'Environment id' })
     .option('version', {
       type: 'number',
       describe: 'Current version of the extension for optimistic locking'
@@ -32,9 +32,9 @@ export async function deleteExtension (argv) {
   await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
 
-  const { cmaToken, activeSpaceId } = await getContext()
+  const { cmaToken, activeSpaceId, activeEnvironmentId } = await getContext()
   const spaceId = argv.spaceId || activeSpaceId
-  const environmentId = argv.environmentId
+  const environmentId = argv.environmentId || activeEnvironmentId || 'master'
 
   const client = await createManagementClient({
     accessToken: argv.managementToken || cmaToken,

--- a/lib/cmds/extension_cmds/get.js
+++ b/lib/cmds/extension_cmds/get.js
@@ -13,7 +13,7 @@ export const builder = (yargs) => {
     .option('id', { type: 'string', demand: true, describe: 'Extension id' })
     .option('management-token', { alias: 'mt', type: 'string', describe: 'Contentful management API token' })
     .option('space-id', { type: 'string', describe: 'Space id' })
-    .option('environment-id', { type: 'string', describe: 'Environment id', default: 'master' })
+    .option('environment-id', { type: 'string', describe: 'Environment id' })
     .epilog('Copyright 2018 Contentful, this is a BETA release')
 }
 
@@ -21,9 +21,9 @@ async function getExtension (argv) {
   await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
 
-  const { cmaToken, activeSpaceId } = await getContext()
+  const { cmaToken, activeSpaceId, activeEnvironmentId } = await getContext()
   const spaceId = argv.spaceId || activeSpaceId
-  const environmentId = argv.environmentId
+  const environmentId = argv.environmentId || activeEnvironmentId || 'master'
 
   const client = await createManagementClient({
     accessToken: argv.managementToken || cmaToken,
@@ -34,7 +34,7 @@ async function getExtension (argv) {
   const environment = await space.getEnvironment(environmentId)
   const extension = await environment.getUiExtension(argv.id)
 
-  logExtension(extension, spaceId)
+  logExtension(extension, spaceId, environmentId)
 }
 
 export const handler = handle(getExtension)

--- a/lib/cmds/extension_cmds/list.js
+++ b/lib/cmds/extension_cmds/list.js
@@ -15,7 +15,7 @@ export const builder = (yargs) => {
   return yargs
     .option('management-token', { alias: 'mt', type: 'string', describe: 'Contentful management API token' })
     .option('space-id', { type: 'string', describe: 'Space id' })
-    .option('environment-id', { type: 'string', describe: 'Environment id', default: 'master' })
+    .option('environment-id', { type: 'string', describe: 'Environment id' })
     .epilog('Copyright 2018 Contentful, this is a BETA release')
 }
 
@@ -23,9 +23,9 @@ export async function listExtensions (argv) {
   await assertLoggedIn(argv)
   await assertSpaceIdProvided(argv)
 
-  const { cmaToken, activeSpaceId } = await getContext()
+  const { cmaToken, activeSpaceId, activeEnvironmentId } = await getContext()
   const spaceId = argv.spaceId || activeSpaceId
-  const environmentId = argv.environmentId
+  const environmentId = argv.environmentId || activeEnvironmentId || 'master'
 
   const client = await createManagementClient({
     accessToken: argv.managementToken || cmaToken,

--- a/lib/cmds/extension_cmds/update.js
+++ b/lib/cmds/extension_cmds/update.js
@@ -24,7 +24,7 @@ export const builder = (yargs) => {
     .option('name', { type: 'string', describe: 'Extension name' })
     .option('management-token', { alias: 'mt', type: 'string', describe: 'Contentful management API token' })
     .option('space-id', { type: 'string', describe: 'Space id' })
-    .option('environment-id', { type: 'string', describe: 'Environment id', default: 'master' })
+    .option('environment-id', { type: 'string', describe: 'Environment id' })
     .option('field-types', { type: 'array', describe: 'Field types' })
     .option('descriptor', { type: 'string', describe: 'Path to an extension descriptor file' })
     .option('src', { type: 'string', describe: 'URL to extension bundle' })
@@ -72,9 +72,9 @@ export async function updateExtensionHandler (argv) {
     await readSrcDocFile(data.extension)
   }
 
-  const { cmaToken, activeSpaceId } = await getContext()
+  const { cmaToken, activeSpaceId, activeEnvironmentId } = await getContext()
   const spaceId = argv.spaceId || activeSpaceId
-  const environmentId = argv.environmentId
+  const environmentId = argv.environmentId || activeEnvironmentId || 'master'
 
   const client = await createManagementClient({
     accessToken: argv.managementToken || cmaToken,
@@ -104,13 +104,13 @@ export async function updateExtensionHandler (argv) {
 
     success(`${successEmoji} Successfully updated extension:\n`)
 
-    logExtension(updated, spaceId)
+    logExtension(updated, spaceId, environmentId)
   } else if (operation === 'create') {
     const created = await createExtension(environment, data)
 
     success(`${successEmoji} Successfully created extension:\n`)
 
-    logExtension(created, spaceId)
+    logExtension(created, spaceId, environmentId)
   }
 }
 

--- a/lib/cmds/extension_cmds/utils/log-as-table.js
+++ b/lib/cmds/extension_cmds/utils/log-as-table.js
@@ -4,7 +4,7 @@ import { get, isArray } from 'lodash'
 import { getDisplayName } from './convert-field-type'
 import { log } from '../../../utils/log'
 
-export function logExtension ({sys, extension, parameters}, spaceId) {
+export function logExtension ({sys, extension, parameters}, spaceId, environmentId = 'master') {
   const table = new Table({
     head: ['Property', 'Value']
   })
@@ -38,8 +38,17 @@ export function logExtension ({sys, extension, parameters}, spaceId) {
     `${Object.keys(installationValues).length}`
   ])
 
+  const url = [
+    'https://app.contentful.com/spaces/',
+    `${spaceId}/`,
+    environmentId !== 'master' ? `environments/${environmentId}/` : '',
+    'settings/extensions/',
+    sys.id
+  ].join('')
+
   log(`Space: ${spaceId}\n`)
-  log(`Your extension: https://app.contentful.com/spaces/${spaceId}/settings/extensions/${sys.id}\n`)
+  log(`Environment: ${environmentId}\n`)
+  log(`Your extension: ${url}\n`)
 
   log(table.toString())
 }

--- a/test/integration/cmds/extension/__snapshots__/create.test.js.snap
+++ b/test/integration/cmds/extension/__snapshots__/create.test.js.snap
@@ -11,7 +11,7 @@ Options:
   --name                     Extension name                             [string]
   --management-token, --mt   Contentful management API token            [string]
   --space-id                 Space id                                   [string]
-  --environment-id           Environment id         [string] [default: \\"master\\"]
+  --environment-id           Environment id                             [string]
   --field-types              Field types                                 [array]
   --descriptor               Path to an extension descriptor file       [string]
   --src                      URL to extension bundle                    [string]

--- a/test/integration/cmds/extension/__snapshots__/delete.test.js.snap
+++ b/test/integration/cmds/extension/__snapshots__/delete.test.js.snap
@@ -10,7 +10,7 @@ Options:
   --id                      Extension id                     [string] [required]
   --management-token, --mt  Contentful management API token             [string]
   --space-id                Space id                                    [string]
-  --environment-id          Environment id          [string] [default: \\"master\\"]
+  --environment-id          Environment id                              [string]
   --version                 Current version of the extension for optimistic
                             locking                                     [number]
   --force                   Force operation without explicit version   [boolean]

--- a/test/integration/cmds/extension/__snapshots__/update.test.js.snap
+++ b/test/integration/cmds/extension/__snapshots__/update.test.js.snap
@@ -11,7 +11,7 @@ Options:
   --name                     Extension name                             [string]
   --management-token, --mt   Contentful management API token            [string]
   --space-id                 Space id                                   [string]
-  --environment-id           Environment id         [string] [default: \\"master\\"]
+  --environment-id           Environment id                             [string]
   --field-types              Field types                                 [array]
   --descriptor               Path to an extension descriptor file       [string]
   --src                      URL to extension bundle                    [string]

--- a/test/unit/cmds/extension_cmds/create.test.js
+++ b/test/unit/cmds/extension_cmds/create.test.js
@@ -35,12 +35,12 @@ const fakeClient = {
 }
 createManagementClient.mockResolvedValue(fakeClient)
 
-getContext.mockResolvedValue({
-  cmaToken: 'mockedToken',
-  activeSpaceId: 'someSpaceId'
-})
-
 beforeEach(() => {
+  getContext.mockReset()
+  getContext.mockResolvedValue({
+    cmaToken: 'mockedToken',
+    activeSpaceId: 'someSpaceId'
+  })
   success.mockClear()
   log.mockClear()
   createManagementClient.mockClear()
@@ -98,7 +98,7 @@ test('Creates extension if field-types is missing', async () => {
     }
   })
   expect(success).toHaveBeenCalledWith(`${successEmoji} Successfully created extension:\n`)
-  expect(log).toHaveBeenCalledTimes(3)
+  expect(log).toHaveBeenCalledTimes(4)
 })
 
 test('Creates extension from command line arguments', async () => {
@@ -117,7 +117,7 @@ test('Creates extension from command line arguments', async () => {
     }
   })
   expect(success).toHaveBeenCalledWith(`${successEmoji} Successfully created extension:\n`)
-  expect(log).toHaveBeenCalledTimes(3)
+  expect(log).toHaveBeenCalledTimes(4)
 })
 
 test('Logs extension data', async () => {
@@ -132,9 +132,39 @@ test('Logs extension data', async () => {
   const values = [ '123', 'Widget', 'Symbol', 'https://awesome.extension' ]
 
   expect(log.mock.calls[0][0]).toContain('Space: space')
-  expect(log.mock.calls[1][0]).toContain('Your extension: https://app.contentful.com/spaces/space/settings/extensions/123')
+  expect(log.mock.calls[1][0]).toContain('Environment: master')
+  expect(log.mock.calls[2][0]).toContain('Your extension: https://app.contentful.com/spaces/space/settings/extensions/123')
   values.forEach(value => {
-    expect(log.mock.calls[2][0]).toContain(value)
+    expect(log.mock.calls[3][0]).toContain(value)
+  })
+
+  expect(success).toHaveBeenCalledWith(`${successEmoji} Successfully created extension:\n`)
+})
+
+test('Uses activeEnvironmentId if environmentId is not specified', async () => {
+  getContext.mockReset()
+  getContext.mockResolvedValue({
+    cmaToken: 'mockedToken',
+    activeSpaceId: 'someSpaceId',
+    activeEnvironmentId: 'test'
+  })
+
+  await createExtensionHandler({
+    spaceId: 'space',
+    name: 'Widget',
+    fieldTypes: ['Symbol'],
+    src: 'https://awesome.extension'
+  })
+
+  const values = [ '123', 'Widget', 'Symbol', 'https://awesome.extension' ]
+
+  expect(log.mock.calls[0][0]).toContain('Space: space')
+  expect(log.mock.calls[1][0]).toContain('Environment: test')
+  expect(log.mock.calls[2][0]).toContain(
+    'Your extension: https://app.contentful.com/spaces/space/environments/test/settings/extensions/123'
+  )
+  values.forEach(value => {
+    expect(log.mock.calls[3][0]).toContain(value)
   })
 
   expect(success).toHaveBeenCalledWith(`${successEmoji} Successfully created extension:\n`)

--- a/test/unit/cmds/extension_cmds/get.test.js
+++ b/test/unit/cmds/extension_cmds/get.test.js
@@ -49,8 +49,9 @@ test('Logs extension data', async () => {
   const outputValues = [ '123', 'Widget', 'Symbol, Symbols', 'https://awesome.extension' ]
 
   expect(log.mock.calls[0][0]).toContain('Space: space1')
-  expect(log.mock.calls[1][0]).toContain('Your extension: https://app.contentful.com/spaces/space1/settings/extensions/123')
+  expect(log.mock.calls[1][0]).toContain('Environment: master')
+  expect(log.mock.calls[2][0]).toContain('Your extension: https://app.contentful.com/spaces/space1/settings/extensions/123')
   outputValues.forEach(str => {
-    expect(log.mock.calls[2][0]).toContain(str)
+    expect(log.mock.calls[3][0]).toContain(str)
   })
 })

--- a/test/unit/cmds/extension_cmds/update.test.js
+++ b/test/unit/cmds/extension_cmds/update.test.js
@@ -29,12 +29,12 @@ const basicExtension = {
 let updateStub
 let fakeClient
 
-getContext.mockResolvedValue({
-  cmaToken: 'mockedToken',
-  activeSpaceId: 'someSpaceId'
-})
-
 beforeEach(() => {
+  getContext.mockResolvedValue({
+    cmaToken: 'mockedToken',
+    activeSpaceId: 'someSpaceId'
+  })
+
   updateStub = jest.fn().mockImplementation((extension) => extension)
 
   fakeClient = {
@@ -59,6 +59,7 @@ afterEach(() => {
   success.mockClear()
   log.mockClear()
   createExtension.mockClear()
+  getContext.mockReset()
 })
 
 test('Throws error if id is missing', async () => {
@@ -156,6 +157,13 @@ test('Calls update on extension and reads srcdoc from disk', async () => {
 })
 
 test('Updates an extension with parameter definitions ', async () => {
+  getContext.mockReset()
+  getContext.mockResolvedValue({
+    cmaToken: 'mockedToken',
+    activeSpaceId: 'someSpaceId',
+    activeEnvironmentId: 'someEnvironmentId'
+  })
+
   const descriptor = `{
     "name": "Test Extension",
     "fieldTypes": ["Boolean"],
@@ -176,11 +184,14 @@ test('Updates an extension with parameter definitions ', async () => {
   })
 
   expect(log.mock.calls[0][0]).toContain('Space: someSpaceId')
-  expect(log.mock.calls[1][0]).toContain('Your extension: https://app.contentful.com/spaces/someSpaceId/settings/extensions/123')
-  expect(log.mock.calls[2][0]).toContain('https://new.extension')
-  expect(log.mock.calls[2][0]).toContain('Boolean')
-  expect(log.mock.calls[2][0]).toContain('Instance: 1')
-  expect(log.mock.calls[2][0]).toContain('Installation: 1')
+  expect(log.mock.calls[1][0]).toContain('Environment: someEnvironmentId')
+  expect(log.mock.calls[2][0]).toContain(
+    'Your extension: https://app.contentful.com/spaces/someSpaceId/environments/someEnvironmentId/settings/extensions/123'
+  )
+  expect(log.mock.calls[3][0]).toContain('https://new.extension')
+  expect(log.mock.calls[3][0]).toContain('Boolean')
+  expect(log.mock.calls[3][0]).toContain('Instance: 1')
+  expect(log.mock.calls[3][0]).toContain('Installation: 1')
 
   expect(updateStub).toHaveBeenCalledTimes(1)
   expect(success).toHaveBeenCalledWith(`${successEmoji} Successfully updated extension:\n`)


### PR DESCRIPTION
## Summary

Fixing the fact that all extensions related commands didn't respect `activeEnviromentId`.

## Motivation and Context

Right now all extensions commands uses `master` environment if user didn't specify `--environment-id` as an argument of the command. 

It's misaligned with `space-id` logic which respects `activeSpaceId`.