### PR TITLE
Change the meaning of notice for user

### DIFF
--- a/lib/cmds/space_cmds/use.js
+++ b/lib/cmds/space_cmds/use.js
@@ -25,7 +25,7 @@ export const builder = (yargs) => {
 }
 
 function showSuccess (space) {
-  success(`Now using the 'master' Environment of Space ${highlightStyle(space.name)} (${highlightStyle(space.sys.id)}) when the \`--space-id\` option is missing.`)
+  success(`Now using the 'master' Environment of Space ${highlightStyle(space.name)} (${highlightStyle(space.sys.id)}) when the \`--environment-id\` option is missing.`)
 }
 
 export async function spaceUse (argv) {


### PR DESCRIPTION
## Summary

Change the note for the CLI user that master will be used as the default environment.

## Description

The `use` command sets the default space for following actions. The notice should state that the `master` environment is used as the default environment if no `--environment-id` parameter has been set.


