### PR TITLE
fix(contentful-import): bump dependency of contentful-import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2495,14 +2495,14 @@
       }
     },
     "contentful-import": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/contentful-import/-/contentful-import-7.3.0.tgz",
-      "integrity": "sha512-FKvv/8uF1PrpvMn7F9jSv1342g2pvrwp12hDn2gNGr3L11DU8s9soNLBiDarW1tTq1TyDr/HGsuYWsT0ZIGcvg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/contentful-import/-/contentful-import-7.4.4.tgz",
+      "integrity": "sha512-W4R79PnHIvqBqSl3R67rZFLj3Udw1ROMKWrht4m3XF1T46NRqFRIzL5VlX9ES1z/QhF7NLZdhC2Yj6otb6WFXA==",
       "requires": {
         "bluebird": "^3.5.1",
         "cli-table3": "^0.5.1",
         "contentful-batch-libs": "^9.0.0",
-        "contentful-management": "^5.3.0",
+        "contentful-management": "^5.7.1",
         "echo-cli": "^1.0.8",
         "joi": "^13.4.0",
         "listr": "^0.14.1",
@@ -2514,14 +2514,35 @@
       },
       "dependencies": {
         "contentful-management": {
-          "version": "5.3.2",
-          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-5.3.2.tgz",
-          "integrity": "sha512-4BsKlKPROb599fKC88//dKabSZ7F0APZryWn2GOHe12Flkhn1R/i1CJELf3Tf3o6guGLf7NSMqrYIQWN3/6ojA==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-5.7.1.tgz",
+          "integrity": "sha512-E344m+U7ltC6NnpRpPEFN4MGUmslS2bnp7syy3OU+KFnSYJ5FDXv2a/RSCTuqndq7MjoGG2GZYsowoQrGiIApA==",
           "requires": {
             "@contentful/axios": "^0.18.0",
-            "contentful-sdk-core": "^6.0.1",
-            "lodash": "^4.17.10"
+            "contentful-sdk-core": "^6.3.1",
+            "lodash": "^4.17.11"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "4.17.11",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+              "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+            }
           }
+        },
+        "contentful-sdk-core": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.3.1.tgz",
+          "integrity": "sha512-tCwx2gEvKEh5tpb70BWQjmxzim3++lZw5mxmnl4WAA6WFBj91ogDMO+cenXULUpm7jARTovN7JBW2X3UMpOSYQ==",
+          "requires": {
+            "lodash": "^4.17.10",
+            "qs": "^6.5.2"
+          }
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
       }
     },
@@ -2536,9 +2557,9 @@
       }
     },
     "contentful-migration": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/contentful-migration/-/contentful-migration-0.17.0.tgz",
-      "integrity": "sha512-b43xvNnPaximbO5SdBGUeLU1yZPMeE0KlX6NUQ9uV8cUbLnj0DD8EzhySB9ywzHc7ZKJozYt3sskeL+azGIf7A==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/contentful-migration/-/contentful-migration-0.17.2.tgz",
+      "integrity": "sha512-LZpYxuyLUfw64sP6Ek9ML7jMHbI/CLcKrQp2h/guEp7NnHtBXip2D5vzlSect4Yx5rzfCB52rgTM011oI2Iq9A==",
       "requires": {
         "bluebird": "^3.5.0",
         "callsites": "^2.0.0",
@@ -2623,12 +2644,12 @@
           }
         },
         "contentful-management": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-5.7.0.tgz",
-          "integrity": "sha512-hXsu9k/nMkSI2OV0zCyVB9thFcRiz2wYesKbMbFlINuAKUbVeOc4DZJQ5/anrb7X4Bin867VHZ3XtvX0+oIcPg==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-5.7.1.tgz",
+          "integrity": "sha512-E344m+U7ltC6NnpRpPEFN4MGUmslS2bnp7syy3OU+KFnSYJ5FDXv2a/RSCTuqndq7MjoGG2GZYsowoQrGiIApA==",
           "requires": {
             "@contentful/axios": "^0.18.0",
-            "contentful-sdk-core": "^6.3.0",
+            "contentful-sdk-core": "^6.3.1",
             "lodash": "^4.17.11"
           },
           "dependencies": {
@@ -2640,9 +2661,9 @@
           }
         },
         "contentful-sdk-core": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.3.0.tgz",
-          "integrity": "sha512-PbZn4OZO/iBk4OjEHir6pX6p4c/q3lwQ3M9pLeibaoiwT8fd3JRfeL4tL0L8M2d9mS8y3g2FRDWmBAI2+0Xlcg==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.3.1.tgz",
+          "integrity": "sha512-tCwx2gEvKEh5tpb70BWQjmxzim3++lZw5mxmnl4WAA6WFBj91ogDMO+cenXULUpm7jARTovN7JBW2X3UMpOSYQ==",
           "requires": {
             "lodash": "^4.17.10",
             "qs": "^6.5.2"
@@ -2819,9 +2840,9 @@
           }
         },
         "qs": {
-          "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
-          "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         },
         "restore-cursor": {
           "version": "2.0.0",
@@ -7269,9 +7290,9 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isemail": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.3.tgz",
-      "integrity": "sha512-5xbsG5wYADIcB+mfLsd+nst1V/D+I7EU7LEZPo2GOIMu4JzfcRs5yQoypP4avA7QtUqgxYLKBYNv4IdzBmbhdw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
       "requires": {
         "punycode": "2.x.x"
       },
@@ -8059,9 +8080,9 @@
       }
     },
     "joi": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.6.0.tgz",
-      "integrity": "sha512-E4QB0yRgEa6ZZKcSHJuBC+QeAwy+akCG0Bsa9edLqljyhlr+GuGDSmXYW1q7sj/FuAPy+ECUI3evVtK52tVfwg==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+      "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
       "requires": {
         "hoek": "5.x.x",
         "isemail": "3.x.x",
@@ -19094,17 +19115,17 @@
       }
     },
     "topo": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
-      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
       "requires": {
-        "hoek": "5.x.x"
+        "hoek": "6.x.x"
       },
       "dependencies": {
         "hoek": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
-          "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+          "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "cli-table3": "^0.5.1",
     "command-exists": "^1.2.7",
     "contentful-export": "^7.3.0",
-    "contentful-import": "^7.5.0",
+    "contentful-import": "^7.4.4",
     "contentful-management": "^6.1.0-beta2",
     "contentful-migration": "^0.17.2",
     "emojic": "^1.1.11",


### PR DESCRIPTION
There was a semantic-release/manual release mix up with contentful-import, so after 7.5.0, version 7.4.4 was published. It includes all the required changes.

This new version of contentful-import points to an updated version of the cma SDK, which includes a fix for passing httpAgent on ratelimit retries.