### PR TITLE
fix: Update token regex

### DIFF
--- a/lib/cmds/login.js
+++ b/lib/cmds/login.js
@@ -52,7 +52,7 @@ export async function login () {
       type: 'input',
       name: 'cmaToken',
       message: 'Paste your token here:',
-      validate: (val) => /^[a-f0-9]{64}$/.test(val.trim())
+      validate: (val) => /^[a-zA-Z0-9_-]{43,64}$/i.test(val.trim()) // token is 43 to 64 cahracters and accept lower/uppercase caharacter plus `-` and `_`
     }
   ])
 


### PR DESCRIPTION
There was an update on your backend that changed the token format which broke the cli validation

Fixes #138 