### PR TITLE
fix(migration): Pass access token correctly to migration lib

### DIFF
--- a/lib/cmds/space_cmds/migration.js
+++ b/lib/cmds/space_cmds/migration.js
@@ -68,7 +68,7 @@ export const migration = async (argv) => {
   const managementApplication = `contentful.cli/${version}`
   const managementFeature = `space-migration`
 
-  const options = { ...argv, spaceId, managementApplication, managementFeature, managementToken }
+  const options = { ...argv, spaceId, managementApplication, managementFeature, accessToken: managementToken }
   if (proxy) {
     // contentful-import and contentful-export
     // expect a string for the proxy config

--- a/test/unit/cmds/space_cmds/migration.test.js
+++ b/test/unit/cmds/space_cmds/migration.test.js
@@ -11,7 +11,7 @@ getContext.mockResolvedValue({ cmaToken: 'managementToken' })
 
 test('it should pass all args to the migration', async () => {
   const stubArgv = {
-    managementToken: 'managementToken',
+    accessToken: 'managementToken',
     managementApplication: `contentful.cli/${version}`,
     spaceId: 'spaceId',
     managementFeature: 'space-migration'


### PR DESCRIPTION
Before, the migration CLI would not pick up the access token passed from `contentful-cli`, instead it would use its own mechanism to resolve `~/.contentfulrc.json`. This was caused by the migration CLI using a [different property name for the access token][1].

[1]: https://github.com/contentful/contentful-migration/blob/master/src/bin/lib/config.ts#L9

