### PR TITLE
chore: Add homebrew install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@
 
 ## :cloud: Installation
 
-Using [npm](http://npmjs.org):
+Using [homebrew](https://brew.sh):
+
+``` sh
+brew install contentful-cli
+```
+
+Using [npm](https://npmjs.org):
 
 ``` sh
 npm install -g contentful-cli


### PR DESCRIPTION
## Summary

Explain a new install method

## Description

There's now https://formulae.brew.sh/formula/contentful-cli to install this tool

## Motivation and Context

To tell people about the new install method

## Todos


## Screenshots (if appropriate):
