### PR TITLE
fix: space use interactive mode

### DIFF
--- a/lib/cmds/space_cmds/environment_cmds/use.js
+++ b/lib/cmds/space_cmds/environment_cmds/use.js
@@ -18,8 +18,7 @@ export const builder = (yargs) => {
     .usage('Usage: contentful space environment use')
     .option('environment-id', {
       alias: 'e',
-      describe: 'ID of the Environment within the currently active Space to use for other commands',
-      demandOption: true
+      describe: 'ID of the Environment within the currently active Space to use for other commands'
     })
     .option('management-token', {
       alias: 'mt',

--- a/lib/config.js
+++ b/lib/config.js
@@ -19,6 +19,7 @@ export default {
     'config remove',
     'space create',
     'space list',
+    'space use',
     'organization list'
   ]
 }


### PR DESCRIPTION
## Summary

Fixes a bug with the interactive `space use` command, reported by @suevalov .

## Description

Fixes a bug reported by @suevalov .
The interactive `space use` and `space use environment` command was not working.
Added the `space use` to the whitelist and made the `--environment-id` flag optional for the `space use environment` command.

## Motivation and Context

Fixes a bug reported by @suevalov .

## Todos

- [x] Implemented fix
