### PR TITLE
Fix: use active environment as default

### DIFF
--- a/lib/cmds/content-type_cmds/get.js
+++ b/lib/cmds/content-type_cmds/get.js
@@ -14,7 +14,7 @@ export const builder = (yargs) => {
     .option('id', { type: 'string', demand: true, describe: 'Content Type id' })
     .option('space-id', { alias: 's', type: 'string', describe: 'Space id' })
     .option('management-token', { alias: 'mt', type: 'string', describe: 'Contentful management API token' })
-    .option('environment-id', { type: 'string', describe: 'Environment id', default: 'master' })
+    .option('environment-id', { type: 'string', describe: 'Environment id' })
     .epilog('Copyright 2018 Contentful, this is a BETA release')
 }
 

--- a/lib/cmds/space_cmds/generate_cmds/migration.js
+++ b/lib/cmds/space_cmds/generate_cmds/migration.js
@@ -28,9 +28,8 @@ export const builder = (yargs) => {
       type: 'string'
     })
     .option('environment-id', {
-      describe: 'ID of the environment the content model will belong to. If not provided, defaults to master',
+      describe: 'ID of the environment the content model will belong to',
       alias: 'e',
-      default: 'master',
       type: 'string'
     })
     .option('content-type-id', {

--- a/lib/cmds/space_cmds/import.js
+++ b/lib/cmds/space_cmds/import.js
@@ -16,7 +16,6 @@ export const builder = (yargs) => {
     .option('environment-id', {
       describe: 'ID the environment in the destination space',
       type: 'string',
-      default: 'master',
       demand: false
     })
     .option('management-token', {

--- a/lib/cmds/space_cmds/migration.js
+++ b/lib/cmds/space_cmds/migration.js
@@ -30,7 +30,6 @@ export const builder = (yargs) => {
     .option('environment-id', {
       alias: 'e',
       describe: 'ID of the environment within the space to run the migration script on',
-      default: 'master'
     })
     .option('management-token', {
       alias: 'mt',


### PR DESCRIPTION
## Summary

Removes static `default` set within yargs `environment-id` option to prevent the active environment from being overriden. 

## Description

The active environment value is used for the `contentful space export` command (thanks to #119), but ignored for several other commands. This PR removes all occurrences of `default: 'master'` in yargs `environment-id` options.

## Motivation and Context

Fixes #160
