### PR TITLE
Added arg type to fix wrong cast to boolean

### DIFF
--- a/lib/cmds/space_cmds/environment_cmds/use.js
+++ b/lib/cmds/space_cmds/environment_cmds/use.js
@@ -18,7 +18,8 @@ export const builder = (yargs) => {
     .usage('Usage: contentful space environment use')
     .option('environment-id', {
       alias: 'e',
-      describe: 'ID of the Environment within the currently active Space to use for other commands'
+      describe: 'ID of the Environment within the currently active Space to use for other commands',
+      type: 'string'
     })
     .option('management-token', {
       alias: 'mt',

--- a/lib/cmds/space_cmds/use.js
+++ b/lib/cmds/space_cmds/use.js
@@ -18,7 +18,8 @@ export const builder = (yargs) => {
     .usage('Usage: contentful space use')
     .option('space-id', {
       alias: 's',
-      describe: 'ID of the Space to use for other commands'
+      describe: 'ID of the Space to use for other commands',
+      type: 'string'
     })
     .epilog('Copyright 2018 Contentful, this is a BETA release')
 }


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->
Fixes misleading error message for `contentful space use --space-id`.

## Description

<!-- Describe your changes in detail -->
Command `contentful space use --space-id`, entered without `space-id` lets you choose interactively from your spaces.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->
Fixes misleading error message for `contentful space use --space-id`.

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

- [x] Implemented Fix
