### PR TITLE
fix(migration): Update migration to use changeFieldControl

### DIFF
--- a/lib/cmds/space_cmds/generate_cmds/migration.js
+++ b/lib/cmds/space_cmds/generate_cmds/migration.js
@@ -220,7 +220,13 @@ const createField = function(ctId, field) {
 
 module.exports.createField = createField
 
-const changeEditorInterface = function(ctId, fieldId, widgetId, settings) {
+const changeFieldControl = function(
+  ctId,
+  fieldId,
+  widgetNamespace,
+  widgetId,
+  settings
+) {
   const ctVariable = ctVariableEscape(ctId)
   settings = settings || {}
 
@@ -233,9 +239,14 @@ const changeEditorInterface = function(ctId, fieldId, widgetId, settings) {
   return b.callExpression(
     b.memberExpression(
       b.identifier(ctVariable),
-      b.identifier('changeEditorInterface')
+      b.identifier('changeFieldControl')
     ),
-    [b.literal(fieldId), b.literal(widgetId), settingsExpression]
+    [
+      b.literal(fieldId),
+      b.literal(widgetNamespace),
+      b.literal(widgetId),
+      settingsExpression
+    ]
   )
 }
 
@@ -245,7 +256,7 @@ const getContentTypes = async function(environment, contentTypeId) {
     : (await environment.getContentTypes()).items
 }
 
-module.exports.changeEditorInterface = changeEditorInterface
+module.exports.changeFieldControl = changeFieldControl
 
 module.exports.getContentTypes = getContentTypes
 
@@ -267,11 +278,17 @@ const generateContentTypeMigration = async function(environment, contentType) {
       const control = _.find(editorInterface.controls, control => {
         return control.fieldId === field.id
       })
-      const widgetId = control.widgetId
-      const settings = control.settings
+
+      const { widgetId, settings, widgetNamespace = 'builtin' } = control
 
       return b.expressionStatement(
-        changeEditorInterface(contentType.sys.id, field.id, widgetId, settings)
+        changeFieldControl(
+          contentType.sys.id,
+          field.id,
+          widgetNamespace,
+          widgetId,
+          settings
+        )
       )
     })
   } catch (err) {
@@ -300,7 +317,8 @@ const generateMigrationScript = async function(environment, contentTypes) {
   )
 
   const output = recast.prettyPrint(migration, { tabWidth: 2 }).code
-  return prettier.format(output)
+
+  return prettier.format(output, { parser: 'babel' })
 }
 
 module.exports.generateMigrationScript = generateMigrationScript

--- a/test/unit/cmds/space_cmds/generate_cmds/migration.test.js
+++ b/test/unit/cmds/space_cmds/generate_cmds/migration.test.js
@@ -104,7 +104,7 @@ test('it doesnt escape name when neither starts with number or is reserved', asy
 })
 
 test('it does escape when name starts with number', async () => {
-  expect(ctVariableEscape('3asd')).toBe('_3Asd')
+  expect(ctVariableEscape('3asd')).toBe('_3asd')
 })
 
 test('it does escape when name is reserved word', async () => {

--- a/test/unit/cmds/space_cmds/generate_cmds/migration.test.js
+++ b/test/unit/cmds/space_cmds/generate_cmds/migration.test.js
@@ -7,7 +7,7 @@ const {
   wrapMigrationWithBase,
   createContentType,
   createField,
-  changeEditorInterface,
+  changeFieldControl,
   generateMigrationScript,
   generateFileName,
   generateMigration
@@ -45,6 +45,7 @@ const editorInterface = {
     {
       fieldId: 'name',
       widgetId: 'singleLine',
+      widgetNamespace: 'builtin',
       settings: {
         helpText: 'the name'
       }
@@ -103,7 +104,7 @@ test('it doesnt escape name when neither starts with number or is reserved', asy
 })
 
 test('it does escape when name starts with number', async () => {
-  expect(ctVariableEscape('3asd')).toBe('_3asd')
+  expect(ctVariableEscape('3asd')).toBe('_3Asd')
 })
 
 test('it does escape when name is reserved word', async () => {
@@ -151,9 +152,10 @@ test('it creates the content type fields', async () => {
 test('it creates the editor interface', async () => {
   const programStub = b.blockStatement([
     b.expressionStatement(
-      changeEditorInterface(
+      changeFieldControl(
         simpleContentType.sys.id,
         editorInterface.controls[0].fieldId,
+        editorInterface.controls[0].widgetNamespace,
         editorInterface.controls[0].widgetId,
         editorInterface.controls[0].settings
       )
@@ -161,7 +163,7 @@ test('it creates the editor interface', async () => {
   ])
 
   const expected = `module.exports = function(migration) {
-    foo.changeEditorInterface("name", "singleLine", {
+    foo.changeFieldControl("name", "builtin", "singleLine", {
         helpText: "the name"
     });
 };`
@@ -183,7 +185,7 @@ test('it creates the full migration script', async () => {
     .name("Name")
     .type("Symbol");
 
-  foo.changeEditorInterface("name", "singleLine", {
+  foo.changeFieldControl("name", "builtin", "singleLine", {
     helpText: "the name"
   });
 };
@@ -245,7 +247,7 @@ test('it generates the migration and writes to disk', async () => {
     .name("Name")
     .type("Symbol");
 
-  foo.changeEditorInterface("name", "singleLine", {
+  foo.changeFieldControl("name", "builtin", "singleLine", {
     helpText: "the name"
   });
 };


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

Update `generate migration` command to use `changeFieldControl` instead of deprecated `changeEditorInterface`.
<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

Replaced `changeEditorInterface` with `changeFieldControl`, added the `widgetNamespace`. 
<!-- Describe your changes in detail -->

## Motivation and Context

Warnings when generating a migration script mentioned in #180 
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

- [x] Implemented changes