### PR TITLE
fix(typo): correct grammer of json space import cli option

### DIFF
--- a/lib/cmds/space_cmds/import.js
+++ b/lib/cmds/space_cmds/import.js
@@ -24,7 +24,7 @@ module.exports.builder = yargs => {
       type: 'string'
     })
     .option('content-file', {
-      describe: 'JSON file that contains data to be import to your space',
+      describe: 'JSON file that contains data to import into a space',
       type: 'string',
       demand: true
     })


### PR DESCRIPTION
## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

For the command `contentful space import` options, `--content-file` has a grammatically incorrect description. 

"JSON file that contains data to be import to your space" is incorrect English. It should be something along the lines of "JSON file that contains data to import into a space" or "JSON file that contains data to be imported into a space". The former is a bit cleaner.

## Motivation and Context

It correctly a typo in the CLI options
