### PR TITLE
feat(config): allow disabling TLS on clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,6 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/vim,code,linux,macos,windows,sublimetext,node
+
+# Our own logs
+contentful-import-error-log-*.json

--- a/lib/cmds/config_cmds/add.js
+++ b/lib/cmds/config_cmds/add.js
@@ -30,6 +30,11 @@ module.exports.builder = yargs => {
       describe: 'active environment id',
       type: 'string'
     })
+    .option('insecure', {
+      describe: 'Use HTTP instead of TLS (default: false)',
+      hidden: true,
+      type: 'boolean'
+    })
     .option('host', {
       alias: 'ho',
       describe: 'management host',
@@ -65,9 +70,10 @@ const addHandler = async argv => {
   const optionsToPick = [
     'managementToken',
     'activeSpaceId',
-    'proxy',
-    'host',
     'activeEnvironmentId',
+    'insecure',
+    'host',
+    'proxy',
     'rawProxy'
   ]
   const opts = pickBy(

--- a/lib/cmds/config_cmds/remove.js
+++ b/lib/cmds/config_cmds/remove.js
@@ -30,6 +30,11 @@ module.exports.builder = yargs => {
       alias: 'ae',
       describe: 'Remove the active environment id from the config'
     })
+    .option('insecure', {
+      describe: 'Use HTTP instead of TLS (default: false)',
+      hidden: true,
+      type: 'boolean'
+    })
     .option('host', {
       alias: 'ho',
       describe: 'Remove the management host from the config'
@@ -62,9 +67,10 @@ const removeHandler = async argv => {
       'managementToken',
       'activeSpaceId',
       'activeEnvironmentId',
+      'insecure',
+      'host',
       'proxy',
       'rawProxy',
-      'host'
     ]
     contextKeys.forEach(key => argv[key] && delete options[key])
   }

--- a/lib/context.js
+++ b/lib/context.js
@@ -99,6 +99,10 @@ async function storeRuntimeConfig() {
     proxy: context.proxy,
     rawProxy: context.rawProxy
   }
+  // Don't write it out unless it's explicitly asked for
+  if (context.insecure) {
+    contextToStore.insecure = context.insecure
+  }
   return writeFile(
     await getConfigPath(),
     JSON.stringify(contextToStore, null, 2) + '\n'

--- a/lib/context.js
+++ b/lib/context.js
@@ -9,6 +9,10 @@ let context
 let configPath
 
 async function getConfigPath() {
+  const pathOverride = process.env.CONTENTFUL_CONFIG_FILE
+  if (pathOverride) {
+    return pathOverride
+  }
   const contentfulrc = '.contentfulrc.json'
   const defaultPath = resolve(homedir(), contentfulrc)
   const nestedConfigPath = await findUp(contentfulrc)

--- a/lib/utils/contentful-clients.js
+++ b/lib/utils/contentful-clients.js
@@ -7,7 +7,7 @@ async function createManagementClient(params) {
   params.application = `contentful.cli/${version}`
 
   const context = await getContext()
-  const { rawProxy, proxy, host } = context
+  const { rawProxy, proxy, host, insecure } = context
 
   const proxyConfig = {}
   if (!rawProxy) {
@@ -17,7 +17,7 @@ async function createManagementClient(params) {
     proxyConfig.proxy = proxy
   }
 
-  return createClient({ ...params, ...proxyConfig, host })
+  return createClient({ ...params, ...proxyConfig, host, insecure })
 }
 
 module.exports.createManagementClient = createManagementClient

--- a/lib/utils/middlewares.js
+++ b/lib/utils/middlewares.js
@@ -17,6 +17,7 @@ module.exports.buildContext = async argv => {
     activeSpaceId,
     environmentId,
     activeEnvironmentId,
+    insecure,
     host,
     rawProxy,
     proxy
@@ -39,6 +40,11 @@ module.exports.buildContext = async argv => {
   }
   if (!context.activeEnvironmentId) {
     context.activeEnvironmentId = 'master'
+  }
+
+  // Only included if explicitly set
+  if (typeof insecure !== 'undefined') {
+    context.insecure = insecure.toString() === 'true'
   }
 
   if (host) {

--- a/test/integration/cmds/config/add.test.js
+++ b/test/integration/cmds/config/add.test.js
@@ -32,6 +32,10 @@ test('config add throws error when option mt is empty', done => {
     .end(done)
 })
 
+test('config add allows insecure', (done) => {
+  app().run('config add --insecure=true').code(0).end(done)
+})
+
 test('config add throws error when option ae is empty', done => {
   app()
     .run('config add --ae')

--- a/test/integration/cmds/config/add.test.js
+++ b/test/integration/cmds/config/add.test.js
@@ -1,7 +1,6 @@
 const nixt = require('nixt')
 const { join } = require('path')
-const { readFileSync } = require('fs')
-const removeHandler = require('../../../../lib/cmds/config_cmds/remove')
+const { setContext, storeRuntimeConfig } = require('../../../../lib/context')
 
 const bin = join(__dirname, './../../../../', 'bin')
 
@@ -39,13 +38,8 @@ test('config add allows insecure', (done) => {
     .run('config add --insecure=true')
     .code(0)
     .end(() => {
-      let context = {}
-      try {
-        context = readFileSync('.contentfulrc.json')
-      } catch (err) {
-        console.warn(err)
-      }
-      return removeHandler({ context, insecure: true }).then(done)
+      setContext({ insecure: false })
+      storeRuntimeConfig().then(done)
     })
 })
 

--- a/test/integration/cmds/config/add.test.js
+++ b/test/integration/cmds/config/add.test.js
@@ -1,8 +1,9 @@
 const nixt = require('nixt')
+const fs = require('fs')
 const { join } = require('path')
-const { setContext, storeRuntimeConfig } = require('../../../../lib/context')
 
 const bin = join(__dirname, './../../../../', 'bin')
+const TMP_CONFIG_FILE = join(fs.mkdtempSync('/tmp/add.test'), '.contentfulrc.json')
 
 const app = () => {
   return nixt({ newlines: true })
@@ -35,12 +36,11 @@ test('config add throws error when option mt is empty', done => {
 
 test('config add allows insecure', (done) => {
   app()
+    .env('CONTENTFUL_CONFIG_FILE', TMP_CONFIG_FILE)
     .run('config add --insecure=true')
+    .unlink(TMP_CONFIG_FILE)
     .code(0)
-    .end(() => {
-      setContext({ insecure: false })
-      storeRuntimeConfig().then(done)
-    })
+    .end(done)
 })
 
 test('config add throws error when option ae is empty', done => {

--- a/test/integration/cmds/config/add.test.js
+++ b/test/integration/cmds/config/add.test.js
@@ -1,5 +1,7 @@
 const nixt = require('nixt')
 const { join } = require('path')
+const { readFileSync } = require('fs')
+const removeHandler = require('../../../../lib/cmds/config_cmds/remove')
 
 const bin = join(__dirname, './../../../../', 'bin')
 
@@ -33,7 +35,18 @@ test('config add throws error when option mt is empty', done => {
 })
 
 test('config add allows insecure', (done) => {
-  app().run('config add --insecure=true').code(0).end(done)
+  app()
+    .run('config add --insecure=true')
+    .code(0)
+    .end(() => {
+      let context = {}
+      try {
+        context = readFileSync('.contentfulrc.json')
+      } catch (err) {
+        console.warn(err)
+      }
+      return removeHandler({ context, insecure: true }).then(done)
+    })
 })
 
 test('config add throws error when option ae is empty', done => {

--- a/test/unit/utils/middlewares.test.js
+++ b/test/unit/utils/middlewares.test.js
@@ -115,6 +115,26 @@ test('useFlagsIfAvailable set rawProxy to true', async () => {
   expect(result).toEqual({ context: { ...defaults.context, rawProxy: true } })
 })
 
+describe('insecure', () => {
+  test('insecure is not specified by default', async () => {
+    getContext.mockResolvedValueOnce({})
+    const result = await buildContext({})
+    expect(result).toEqual({ context: defaults.context })
+  })
+
+  test('insecure can be set to true in base context', async () => {
+    getContext.mockResolvedValueOnce({ insecure: true })
+    const result = await buildContext({})
+    expect(result).toEqual({ context: { ...defaults.context, insecure: true } })
+  })
+
+  test('insecure can be set to true manually', async () => {
+    getContext.mockResolvedValueOnce({})
+    const result = await buildContext({ insecure: true })
+    expect(result).toEqual({ context: { ...defaults.context, insecure: true } })
+  })
+})
+
 test('useFlagsIfAvailable set rawProxy to false', async () => {
   getContext.mockResolvedValueOnce({})
   const result = await buildContext({ rawProxy: false })


### PR DESCRIPTION
## Summary

feat: Adds a hidden config option for passing 'insecure' to the client, allowing for local development
feat: Allow specifying the config file path in environment with `CONTENTFUL_CONFIG_FILE`