### PR TITLE
fix(login-input): Mask token paste input

### DIFF
--- a/lib/cmds/login.js
+++ b/lib/cmds/login.js
@@ -83,7 +83,7 @@ async function login({ context, managementToken: managementTokenFlag }) {
 
     const tokenAnswer = await inquirer.prompt([
       {
-        type: 'input',
+        type: 'password',
         name: 'managementToken',
         message: 'Paste your token here:',
         validate: val => /^[a-zA-Z0-9_-]{43,64}$/i.test(val.trim()) // token is 43 to 64 characters and accepts lower/uppercase characters plus `-` and `_`


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

Masks token pasting when logging in. Previous pull request was breaking circleci for some reason

## Description

Uses input type "password" instead of "input" as we're dealing with secret tokens.

## Motivation and Context

Security focused where tokens aren't availabe in CLI output logs.
