### PR TITLE
fix(migration): do not use strict mode

### DIFF
--- a/lib/cmds/space_cmds/migration.js
+++ b/lib/cmds/space_cmds/migration.js
@@ -56,7 +56,6 @@ module.exports.builder = yargs => {
     .help('h')
     .alias('h', 'help')
     .example('contentful space migration', '--space-id abcedef my-migration.js')
-    .strict()
     .config(
       'config',
       'An optional configuration JSON file containing all the options for a single run'


### PR DESCRIPTION
This attempts to fix a bug caused by a breaking yargs change (yargs parser now throws on invalid config)