### PR TITLE
fix(args): proxy must be passed as a string to export/import/migration

### DIFF
--- a/lib/cmds/space_cmds/export.js
+++ b/lib/cmds/space_cmds/export.js
@@ -142,15 +142,13 @@ const exportSpace = async argv => {
     proxy,
     rawProxy
   } = context
-  const managementApplication = `contentful.cli/${version}`
-  const managementFeature = feature
 
   const options = {
     ...argv,
     spaceId: activeSpaceId,
     environmentId: activeEnvironmentId,
-    managementApplication,
-    managementFeature,
+    managementApplication: `contentful.cli/${version}`,
+    managementFeature: feature,
     managementToken,
     host
   }
@@ -159,9 +157,15 @@ const exportSpace = async argv => {
     // contentful-import and contentful-export
     // expect a string for the proxy config
     // and create agents from it
-    options.proxy = proxyObjectToString(proxy)
+    if (typeof proxy !== 'string') {
+      options.proxy = proxyObjectToString(proxy)
+    } else {
+      options.proxy = proxy
+    }
+
     options.rawProxy = rawProxy
   }
+
   const exportResult = await runContentfulExport(options)
   logging.success(`${emojic.sparkles} Done`)
   return exportResult

--- a/lib/cmds/space_cmds/import.js
+++ b/lib/cmds/space_cmds/import.js
@@ -110,13 +110,20 @@ const importSpace = async argv => {
     managementToken,
     host
   }
+
   if (proxy) {
     // contentful-import and contentful-export
     // expect a string for the proxy config
     // and create agents from it
-    options.proxy = proxyObjectToString(proxy)
+    if (typeof proxy !== 'string') {
+      options.proxy = proxyObjectToString(proxy)
+    } else {
+      options.proxy = proxy
+    }
+
     options.rawProxy = rawProxy
   }
+
   return runContentfulImport(options)
 }
 

--- a/lib/utils/proxy.js
+++ b/lib/utils/proxy.js
@@ -51,6 +51,9 @@ function proxyStringToObject(proxyString) {
 module.exports.proxyStringToObject = proxyStringToObject
 
 function proxyObjectToString(proxyObject) {
+  if (typeof proxyObject !== 'object' || proxyObject.constructor !== Object) {
+    throw new Error('Object required')
+  }
   const { host: hostname, port, auth: authObject, isHttps } = proxyObject
   const auth = serializeAuth(authObject)
   const protocol = isHttps ? 'https' : 'http'


### PR DESCRIPTION
Proxy args are represented internally as an object in most cases (when loaded from config, when loaded from the ENV..), but must be passed to other cli tools (export/import/migration) as strings. In the case where the proxy arg is from the command line and the call is for export/import (migration doesn't support the proxy command line arg) the string arg was treated as an object, and so using the arg would lead to an error. This change passes the string directly.

(the unrelated change with management* is just to make export more closely match import) 