### PR TITLE
fix(circle): update xcode for bump-brew-formula CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
       - run: npm run semantic-release
   bump-brew-formula:
     macos:
-      xcode: '9.0'
+      xcode: '11.0'
     steps:
       - checkout
       - run: npm run bump-brew-formula


### PR DESCRIPTION
Circleci is deprecating xcode images for v9.0. I don't see a reason that xcode has to be at this old version in order to run our `bump brew formula` step, so I'm updating it without further changes. I'm making this a "fix" so that we can test that the release step and homebrew step work correctly.