### PR TITLE
fix(circleci): increase no-output-timeout for bump-brew step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,13 +59,12 @@ jobs:
       - run: npm run build:package
       - run: npm run semantic-release
   bump-brew-formula:
+    no_output_timeout: 30m
     macos:
       xcode: '11.0'
     steps:
       - checkout
-      - run:
-        command: npm run bump-brew-formula
-        no_output_timeout: 30m
+      - run: npm run bump-brew-formula
   audit: &audit
     docker:
       - image: circleci/node:12


### PR DESCRIPTION
This fixes an invalid circle config which was pushed to master