### PR TITLE
fix(config): add no output timeout to bump-brew-formula CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,12 +59,14 @@ jobs:
       - run: npm run build:package
       - run: npm run semantic-release
   bump-brew-formula:
-    no_output_timeout: 30m
     macos:
       xcode: '11.0'
     steps:
       - checkout
-      - run: npm run bump-brew-formula
+      - run:
+          name: bump brew formula
+          command: npm run bump-brew-formula
+          no_output_timeout: 30m
   audit: &audit
     docker:
       - image: circleci/node:12


### PR DESCRIPTION
Finally fix this brew formula thing since upgrading the xcode version there.