### PR TITLE
fix(aliases): sort by id instead of name

### DIFF
--- a/lib/cmds/space_cmds/alias_cmds/list.js
+++ b/lib/cmds/space_cmds/alias_cmds/list.js
@@ -43,7 +43,7 @@ module.exports.environmentAliasList = async function environmentAliasList({
     method: 'getEnvironmentAliases'
   })
 
-  const aliases = result.items.sort((a, b) => a.name.localeCompare(b.name))
+  const aliases = result.items.sort((a, b) => a.sys.id.localeCompare(b.sys.id))
 
   const table = new Table({
     head: ['Alias id', 'Target environment ID']


### PR DESCRIPTION
For more than one alias, the old attempted sorting would break as there is no name property to refer to. We now sort by id to fix this.