### PR TITLE
fix(ci): address shallow cloning for homebrew

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,7 @@ jobs:
       xcode: '11.0'
     steps:
       - checkout
+      - run: git -C "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core" fetch --unshallow
       - run:
           name: bump brew formula
           command: npm run bump-brew-formula


### PR DESCRIPTION
Homebrew-core is now a shallow clone in our brew step, now we explicitly fetch with the --unshallow option 
Context: https://github.com/Homebrew/brew/pull/9383