### PR TITLE
fix(build): only run brew formula update on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,3 +120,6 @@ workflows:
       - bump-brew-formula:
           requires:
             - release
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
## Description
Currently, we're running the script on every push:
The task es very time consuming and also downloads > 500MB

Since there is no benefit in doing it other than for releases, we will filter by branches now
