### PR TITLE
fix(export-assets): bump contentful export version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3324,9 +3324,9 @@
       }
     },
     "contentful-export": {
-      "version": "7.11.4",
-      "resolved": "https://registry.npmjs.org/contentful-export/-/contentful-export-7.11.4.tgz",
-      "integrity": "sha512-fL4tDTIxMpzhgRbHPTot88XqsruZmq3N/vBl4QLRcrcQ2UHya6EpSOLuhXbXQ1Bu3rykwTrBijgylznjQZ0jAQ==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/contentful-export/-/contentful-export-7.11.5.tgz",
+      "integrity": "sha512-zKBL2gjeCJeYkSKOf4xK7e8g6cybeAz5K7UFl4/e/8CR1gsMwd2I+ouhygEp4Wa7JtwqTKCIJysWg1t4srN8oA==",
       "requires": {
         "bfj": "^7.0.2",
         "bluebird": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "chalk": "^2.4.1",
     "cli-table3": "^0.6.0",
     "command-exists": "^1.2.7",
-    "contentful-export": "^7.10.17",
+    "contentful-export": "^7.11.5",
     "contentful-import": "^7.9.23",
     "contentful-management": "^7.3.1",
     "contentful-migration": "^4.0.0",


### PR DESCRIPTION
## Summary

Bump contentful export version:

This export version will handle assets that were not successfully processed and notify the user of which of them had issues.

