### PR TITLE
feat: support passing additional HTTP headers

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,6 @@
 {
   "singleQuote": true,
-  "semi": false
+  "semi": false,
+  "trailingComma": "none",
+  "arrowParens": "avoid"
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -26,7 +26,7 @@ yargs
   })
   .version(false)
   .epilog('Copyright 2019 Contentful')
-  .fail(function(msg, err, yargs) {
+  .fail(function (msg, err, yargs) {
     if (err) throw err
     console.error(yargs.help())
     console.error(msg)

--- a/lib/cmds/config.js
+++ b/lib/cmds/config.js
@@ -2,7 +2,7 @@ module.exports.command = 'config'
 
 module.exports.desc = 'Manage and list your configs'
 
-module.exports.builder = function(yargs) {
+module.exports.builder = function (yargs) {
   return yargs
     .commandDir('config_cmds')
     .demandCommand(4, 'Please specify a sub command.')

--- a/lib/cmds/config_cmds/remove.js
+++ b/lib/cmds/config_cmds/remove.js
@@ -70,7 +70,7 @@ const removeHandler = async argv => {
       'insecure',
       'host',
       'proxy',
-      'rawProxy',
+      'rawProxy'
     ]
     contextKeys.forEach(key => argv[key] && delete options[key])
   }

--- a/lib/cmds/content-type.js
+++ b/lib/cmds/content-type.js
@@ -3,7 +3,7 @@ module.exports.aliases = ['ct']
 
 module.exports.desc = 'Manage and list your space content types'
 
-module.exports.builder = function(yargs) {
+module.exports.builder = function (yargs) {
   return yargs
     .commandDir('content-type_cmds')
     .demandCommand(4, 'Please specify a sub command.')

--- a/lib/cmds/content-type_cmds/get.js
+++ b/lib/cmds/content-type_cmds/get.js
@@ -23,7 +23,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .epilog('Copyright 2019 Contentful')
 }

--- a/lib/cmds/content-type_cmds/get.js
+++ b/lib/cmds/content-type_cmds/get.js
@@ -4,6 +4,7 @@ const { createManagementClient } = require('../../utils/contentful-clients')
 const { log } = require('../../utils/log')
 const { handleAsyncError: handle } = require('../../utils/async')
 const { getId } = require('../../utils/helpers')
+const { getHeadersFromOption } = require('../../utils/headers')
 
 module.exports.command = 'get'
 
@@ -19,6 +20,11 @@ module.exports.builder = yargs => {
       describe: 'Contentful management API token'
     })
     .option('environment-id', { type: 'string', describe: 'Environment id' })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .epilog('Copyright 2019 Contentful')
 }
 
@@ -28,7 +34,8 @@ async function ctShow(argv) {
 
   const client = await createManagementClient({
     accessToken: managementToken,
-    feature: 'content_type-get'
+    feature: 'content_type-get',
+    headers: getHeadersFromOption(argv.header)
   })
 
   const space = await client.getSpace(activeSpaceId)

--- a/lib/cmds/content-type_cmds/list.js
+++ b/lib/cmds/content-type_cmds/list.js
@@ -30,7 +30,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .epilog('Copyright 2019 Contentful')
 }

--- a/lib/cmds/content-type_cmds/list.js
+++ b/lib/cmds/content-type_cmds/list.js
@@ -5,6 +5,7 @@ const { handleAsyncError: handle } = require('../../utils/async')
 const { log } = require('../../utils/log')
 const paginate = require('../../utils/pagination')
 const { highlightStyle } = require('../../utils/styles')
+const { getHeadersFromOption } = require('../../utils/headers')
 
 module.exports.command = 'list'
 
@@ -26,15 +27,21 @@ module.exports.builder = yargs => {
       describe:
         'Environment ID you want to interact with. Defaults to the current active environment.'
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .epilog('Copyright 2019 Contentful')
 }
 
-async function ctList({ context }) {
+async function ctList({ header, context }) {
   const { managementToken, activeSpaceId, activeEnvironmentId } = context
 
   const client = await createManagementClient({
     accessToken: managementToken,
-    feature: 'content_type-list'
+    feature: 'content_type-list',
+    headers: getHeadersFromOption(header)
   })
 
   const space = await client.getSpace(activeSpaceId)

--- a/lib/cmds/extension.js
+++ b/lib/cmds/extension.js
@@ -2,7 +2,7 @@ module.exports.command = 'extension'
 
 module.exports.desc = 'Manage and list your extensions'
 
-module.exports.builder = function(yargs) {
+module.exports.builder = function (yargs) {
   return yargs
     .commandDir('extension_cmds')
     .demandCommand(4, 'Please specify a sub command.')

--- a/lib/cmds/extension_cmds/create.js
+++ b/lib/cmds/extension_cmds/create.js
@@ -45,7 +45,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .epilog('Copyright 2019 Contentful')
 }

--- a/lib/cmds/extension_cmds/create.js
+++ b/lib/cmds/extension_cmds/create.js
@@ -1,6 +1,7 @@
 const { handleAsyncError: handle } = require('../../utils/async')
 const { createManagementClient } = require('../../utils/contentful-clients')
 const { successEmoji } = require('../../utils/emojis')
+const { getHeadersFromOption } = require('../../utils/headers')
 const { success } = require('../../utils/log')
 
 const { assertExtensionValuesProvided } = require('./utils/assertions')
@@ -41,6 +42,11 @@ module.exports.builder = yargs => {
       type: 'string',
       describe: 'JSON string of installation parameter key-value pairs'
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .epilog('Copyright 2019 Contentful')
 }
 
@@ -73,7 +79,8 @@ async function createExtensionHandler(argv) {
 
   const client = await createManagementClient({
     accessToken: managementToken,
-    feature: 'extension-create'
+    feature: 'extension-create',
+    headers: getHeadersFromOption(argv.header)
   })
 
   const space = await client.getSpace(activeSpaceId)

--- a/lib/cmds/extension_cmds/delete.js
+++ b/lib/cmds/extension_cmds/delete.js
@@ -1,6 +1,7 @@
 const { handleAsyncError: handle } = require('../../utils/async')
 const { createManagementClient } = require('../../utils/contentful-clients')
 const { successEmoji } = require('../../utils/emojis')
+const { getHeadersFromOption } = require('../../utils/headers')
 const { success } = require('../../utils/log')
 
 const { assertForceOrCorrectVersionProvided } = require('./utils/assertions')
@@ -27,6 +28,11 @@ module.exports.builder = yargs => {
       type: 'boolean',
       describe: 'Force operation without explicit version'
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .epilog('Copyright 2019 Contentful')
 }
 
@@ -36,7 +42,8 @@ async function deleteExtension(argv) {
 
   const client = await createManagementClient({
     accessToken: managementToken,
-    feature: 'extension-delete'
+    feature: 'extension-delete',
+    headers: getHeadersFromOption(argv.header)
   })
 
   const space = await client.getSpace(activeSpaceId)

--- a/lib/cmds/extension_cmds/delete.js
+++ b/lib/cmds/extension_cmds/delete.js
@@ -31,7 +31,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .epilog('Copyright 2019 Contentful')
 }

--- a/lib/cmds/extension_cmds/get.js
+++ b/lib/cmds/extension_cmds/get.js
@@ -20,7 +20,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .epilog('Copyright 2019 Contentful')
 }

--- a/lib/cmds/extension_cmds/get.js
+++ b/lib/cmds/extension_cmds/get.js
@@ -1,6 +1,7 @@
 const { createManagementClient } = require('../../utils/contentful-clients')
 const { handleAsyncError: handle } = require('../../utils/async')
 const { logExtension } = require('./utils/log-as-table')
+const { getHeadersFromOption } = require('../../utils/headers')
 
 module.exports.command = 'get'
 
@@ -16,15 +17,21 @@ module.exports.builder = yargs => {
     })
     .option('space-id', { type: 'string', describe: 'Space id' })
     .option('environment-id', { type: 'string', describe: 'Environment id' })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .epilog('Copyright 2019 Contentful')
 }
 
-async function getExtension({ context, id }) {
+async function getExtension({ context, id, header }) {
   const { managementToken, activeSpaceId, activeEnvironmentId } = context
 
   const client = await createManagementClient({
     accessToken: managementToken,
-    feature: 'extension-get'
+    feature: 'extension-get',
+    headers: getHeadersFromOption(header)
   })
 
   const space = await client.getSpace(activeSpaceId)

--- a/lib/cmds/extension_cmds/list.js
+++ b/lib/cmds/extension_cmds/list.js
@@ -4,6 +4,7 @@ const { createManagementClient } = require('../../utils/contentful-clients')
 const { handleAsyncError: handle } = require('../../utils/async')
 const { log } = require('../../utils/log')
 const paginate = require('../../utils/pagination')
+const { getHeadersFromOption } = require('../../utils/headers')
 
 module.exports.command = 'list'
 
@@ -18,15 +19,21 @@ module.exports.builder = yargs => {
     })
     .option('space-id', { type: 'string', describe: 'Space id' })
     .option('environment-id', { type: 'string', describe: 'Environment id' })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .epilog('Copyright 2019 Contentful')
 }
 
-async function listExtensions({ context }) {
+async function listExtensions({ context, header }) {
   const { managementToken, activeSpaceId, activeEnvironmentId } = context
 
   const client = await createManagementClient({
     accessToken: managementToken,
-    feature: 'extension-list'
+    feature: 'extension-list',
+    headers: getHeadersFromOption(header)
   })
 
   const space = await client.getSpace(activeSpaceId)

--- a/lib/cmds/extension_cmds/list.js
+++ b/lib/cmds/extension_cmds/list.js
@@ -22,7 +22,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .epilog('Copyright 2019 Contentful')
 }

--- a/lib/cmds/extension_cmds/update.js
+++ b/lib/cmds/extension_cmds/update.js
@@ -1,6 +1,7 @@
 const { handleAsyncError: handle } = require('../../utils/async')
 const { createManagementClient } = require('../../utils/contentful-clients')
 const { successEmoji } = require('../../utils/emojis')
+const { getHeadersFromOption } = require('../../utils/headers')
 const { success } = require('../../utils/log')
 const { createExtension } = require('./create')
 
@@ -53,6 +54,11 @@ module.exports.builder = yargs => {
       type: 'string',
       describe: 'JSON string of installation parameter key-value pairs'
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .epilog('Copyright 2019 Contentful')
 }
 
@@ -80,7 +86,8 @@ async function updateExtensionHandler(argv) {
 
   const client = await createManagementClient({
     accessToken: managementToken,
-    feature: 'extension-update'
+    feature: 'extension-update',
+    headers: getHeadersFromOption(argv.header)
   })
 
   const space = await client.getSpace(activeSpaceId)

--- a/lib/cmds/extension_cmds/update.js
+++ b/lib/cmds/extension_cmds/update.js
@@ -57,7 +57,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .epilog('Copyright 2019 Contentful')
 }

--- a/lib/cmds/organization.js
+++ b/lib/cmds/organization.js
@@ -2,7 +2,7 @@ module.exports.command = 'organization'
 
 module.exports.desc = 'Manage and list your organizations'
 
-module.exports.builder = function(yargs) {
+module.exports.builder = function (yargs) {
   return yargs
     .usage('')
     .commandDir('organization_cmds')

--- a/lib/cmds/organization_cmds/list.js
+++ b/lib/cmds/organization_cmds/list.js
@@ -21,7 +21,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .epilog(
       [

--- a/lib/cmds/organization_cmds/list.js
+++ b/lib/cmds/organization_cmds/list.js
@@ -2,6 +2,7 @@ const Table = require('cli-table3')
 
 const { handleAsyncError: handle } = require('../../utils/async')
 const { createManagementClient } = require('../../utils/contentful-clients')
+const { getHeadersFromOption } = require('../../utils/headers')
 const { log } = require('../../utils/log')
 const paginate = require('../../utils/pagination')
 
@@ -17,6 +18,11 @@ module.exports.builder = yargs => {
       describe: 'Contentful management API token',
       type: 'string'
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .epilog(
       [
         'See more at:',
@@ -28,12 +34,13 @@ module.exports.builder = yargs => {
 
 module.exports.aliases = ['ls']
 
-async function organizationList({ context }) {
+async function organizationList({ context, header }) {
   const { managementToken } = context
 
   const client = await createManagementClient({
     accessToken: managementToken,
-    feature: 'organization-list'
+    feature: 'organization-list',
+    headers: getHeadersFromOption(header)
   })
 
   const result = await paginate({ client, method: 'getOrganizations' })

--- a/lib/cmds/snake.js
+++ b/lib/cmds/snake.js
@@ -11,7 +11,7 @@ const FOOD = '@'
 let interval
 let score = 0
 
-module.exports.handler = function() {
+module.exports.handler = function () {
   const screen = blessed.screen({
     smartCSR: true
   })
@@ -35,17 +35,17 @@ module.exports.handler = function() {
 
   screen.append(game)
 
-  interval = setInterval(function() {
+  interval = setInterval(function () {
     game.setContent(board.update())
     screen.render()
   }, INTERVAL)
 
-  screen.key(['left', 'right', 'up', 'down'], function(ch, key) {
+  screen.key(['left', 'right', 'up', 'down'], function (ch, key) {
     DIRECTION = key.full
   })
 
   // Quit on Escape, q, or Control-C.
-  screen.key(['escape', 'q', 'C-c'], function() {
+  screen.key(['escape', 'q', 'C-c'], function () {
     return process.exit(0)
   })
 

--- a/lib/cmds/space.js
+++ b/lib/cmds/space.js
@@ -2,7 +2,7 @@ module.exports.command = 'space'
 
 module.exports.desc = 'Manage and list your spaces'
 
-module.exports.builder = function(yargs) {
+module.exports.builder = function (yargs) {
   return yargs
     .usage('')
     .commandDir('space_cmds')

--- a/lib/cmds/space_cmds/accesstoken.js
+++ b/lib/cmds/space_cmds/accesstoken.js
@@ -4,7 +4,7 @@ module.exports.desc = 'Manage and list your delivery access tokens'
 
 module.exports.aliases = ['at']
 
-module.exports.builder = function(yargs) {
+module.exports.builder = function (yargs) {
   return yargs
     .commandDir('accesstoken_cmds')
     .demandCommand(5, 'Please specify a sub command.')

--- a/lib/cmds/space_cmds/accesstoken_cmds/create.js
+++ b/lib/cmds/space_cmds/accesstoken_cmds/create.js
@@ -1,6 +1,7 @@
 const { handleAsyncError: handle } = require('../../../utils/async')
 const { createManagementClient } = require('../../../utils/contentful-clients')
 const { successEmoji } = require('../../../utils/emojis')
+const { getHeadersFromOption } = require('../../../utils/headers')
 const { success } = require('../../../utils/log')
 const paginate = require('../../../utils/pagination')
 const { highlightStyle } = require('../../../utils/styles')
@@ -34,6 +35,11 @@ module.exports.builder = yargs => {
       describe: 'Suppress command output',
       default: false
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .epilog('Copyright 2019 Contentful')
 }
 
@@ -49,7 +55,8 @@ async function accessTokenCreate(argv) {
 
   const client = await createManagementClient({
     accessToken: managementToken,
-    feature
+    feature,
+    headers: getHeadersFromOption(argv.header)
   })
 
   const space = await client.getSpace(activeSpaceId)

--- a/lib/cmds/space_cmds/accesstoken_cmds/create.js
+++ b/lib/cmds/space_cmds/accesstoken_cmds/create.js
@@ -38,7 +38,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .epilog('Copyright 2019 Contentful')
 }

--- a/lib/cmds/space_cmds/accesstoken_cmds/list.js
+++ b/lib/cmds/space_cmds/accesstoken_cmds/list.js
@@ -25,7 +25,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .usage('Usage: contentful space accesstoken list')
     .epilog(epilog)

--- a/lib/cmds/space_cmds/accesstoken_cmds/list.js
+++ b/lib/cmds/space_cmds/accesstoken_cmds/list.js
@@ -2,6 +2,7 @@ const Table = require('cli-table3')
 
 const { handleAsyncError: handle } = require('../../../utils/async')
 const { createManagementClient } = require('../../../utils/contentful-clients')
+const { getHeadersFromOption } = require('../../../utils/headers')
 const { log } = require('../../../utils/log')
 const paginate = require('../../../utils/pagination')
 
@@ -21,18 +22,24 @@ module.exports.builder = yargs => {
       type: 'string'
     })
     .option('space-id', { alias: 's', type: 'string', describe: 'Space id' })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .usage('Usage: contentful space accesstoken list')
     .epilog(epilog)
 }
 
 module.exports.aliases = ['ls']
 
-async function accessTokenList({ context }) {
+async function accessTokenList({ context, header }) {
   const { managementToken, activeSpaceId } = context
 
   const client = await createManagementClient({
     accessToken: managementToken,
-    feature: 'space-access_token-list'
+    feature: 'space-access_token-list',
+    headers: getHeadersFromOption(header)
   })
 
   const space = await client.getSpace(activeSpaceId)

--- a/lib/cmds/space_cmds/alias.js
+++ b/lib/cmds/space_cmds/alias.js
@@ -2,7 +2,7 @@ module.exports.command = 'environment-alias'
 
 module.exports.desc = 'Manage and list environment aliases'
 
-module.exports.builder = function(yargs) {
+module.exports.builder = function (yargs) {
   return yargs
     .usage('')
     .commandDir('alias_cmds')

--- a/lib/cmds/space_cmds/alias_cmds/list.js
+++ b/lib/cmds/space_cmds/alias_cmds/list.js
@@ -2,6 +2,7 @@ const Table = require('cli-table3')
 
 const { handleAsyncError: handle } = require('../../../utils/async')
 const { createManagementClient } = require('../../../utils/contentful-clients')
+const { getHeadersFromOption } = require('../../../utils/headers')
 const { log } = require('../../../utils/log')
 const paginate = require('../../../utils/pagination')
 
@@ -22,18 +23,25 @@ module.exports.builder = yargs => {
       describe: 'Contentful management API token',
       type: 'string'
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
 }
 
 module.exports.aliases = ['ls']
 
 module.exports.environmentAliasList = async function environmentAliasList({
-  context
+  context,
+  header
 }) {
   const { managementToken, activeSpaceId } = context
 
   const client = await createManagementClient({
     accessToken: managementToken,
-    feature: 'space-environment-alias-list'
+    feature: 'space-environment-alias-list',
+    headers: getHeadersFromOption(header)
   })
 
   const space = await client.getSpace(activeSpaceId)

--- a/lib/cmds/space_cmds/alias_cmds/list.js
+++ b/lib/cmds/space_cmds/alias_cmds/list.js
@@ -26,7 +26,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
 }
 

--- a/lib/cmds/space_cmds/alias_cmds/update.js
+++ b/lib/cmds/space_cmds/alias_cmds/update.js
@@ -1,6 +1,7 @@
 const logging = require('../../../utils/log')
 const { handleAsyncError: handle } = require('../../../utils/async')
 const { createManagementClient } = require('../../../utils/contentful-clients')
+const { getHeadersFromOption } = require('../../../utils/headers')
 
 module.exports.command = 'update'
 
@@ -31,18 +32,25 @@ module.exports.builder = yargs => {
       describe: 'Contentful management API token',
       type: 'string'
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
 }
 
 module.exports.environmentAliasUpdate = async function environmentAliasUpdate({
   context,
   aliasId,
-  targetEnvironmentId
+  targetEnvironmentId,
+  header
 }) {
   const { managementToken, activeSpaceId } = context
 
   const client = await createManagementClient({
     accessToken: managementToken,
-    feature: 'space-environment-alias-update'
+    feature: 'space-environment-alias-update',
+    headers: getHeadersFromOption(header)
   })
 
   const space = await client.getSpace(activeSpaceId)

--- a/lib/cmds/space_cmds/alias_cmds/update.js
+++ b/lib/cmds/space_cmds/alias_cmds/update.js
@@ -35,7 +35,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
 }
 

--- a/lib/cmds/space_cmds/create.js
+++ b/lib/cmds/space_cmds/create.js
@@ -15,6 +15,7 @@ const createSpaceIntents = require('../../core/event-handlers/intents/create-spa
 const createSpaceLogging = require('../../core/event-handlers/logging/create-space-handler')
 
 const { AbortedError } = require('../../guide/helpers')
+const { getHeadersFromOption } = require('../../utils/headers')
 
 module.exports.command = 'create'
 
@@ -53,6 +54,11 @@ module.exports.builder = yargs => {
         'Use the created space as default space when the --space-id is skipped.',
       type: 'boolean'
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .epilog('Copyright 2019 Contentful')
 }
 
@@ -69,8 +75,9 @@ async function spaceCreate(argv) {
   const { managementToken } = context
   let { organizationId } = argv
   const client = await createManagementClient({
+    feature,
     accessToken: managementToken,
-    feature
+    headers: getHeadersFromOption(argv.header)
   })
 
   logging.log(

--- a/lib/cmds/space_cmds/create.js
+++ b/lib/cmds/space_cmds/create.js
@@ -57,7 +57,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .epilog('Copyright 2019 Contentful')
 }

--- a/lib/cmds/space_cmds/delete.js
+++ b/lib/cmds/space_cmds/delete.js
@@ -29,7 +29,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .epilog('Copyright 2019 Contentful')
 }

--- a/lib/cmds/space_cmds/delete.js
+++ b/lib/cmds/space_cmds/delete.js
@@ -2,6 +2,7 @@ const { confirmation } = require('../../utils/actions')
 const { handleAsyncError: handle } = require('../../utils/async')
 const { createManagementClient } = require('../../utils/contentful-clients')
 const { successEmoji } = require('../../utils/emojis')
+const { getHeadersFromOption } = require('../../utils/headers')
 const { log, success } = require('../../utils/log')
 const { highlightStyle, warningStyle } = require('../../utils/styles')
 
@@ -25,13 +26,19 @@ module.exports.builder = yargs => {
     .option('yes', {
       describe: 'Skip the confirmation question'
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .epilog('Copyright 2019 Contentful')
 }
 
-async function spaceDelete({ context, yes }) {
+async function spaceDelete({ context, yes, header }) {
   const { managementToken, activeSpaceId } = context
   const client = await createManagementClient({
-    accessToken: managementToken
+    accessToken: managementToken,
+    headers: getHeadersFromOption(header)
   })
 
   const space = await client.getSpace(activeSpaceId)

--- a/lib/cmds/space_cmds/environment.js
+++ b/lib/cmds/space_cmds/environment.js
@@ -2,7 +2,7 @@ module.exports.command = 'environment'
 
 module.exports.desc = 'Manage and list environments'
 
-module.exports.builder = function(yargs) {
+module.exports.builder = function (yargs) {
   return yargs
     .usage('')
     .commandDir('environment_cmds')

--- a/lib/cmds/space_cmds/environment_cmds/create.js
+++ b/lib/cmds/space_cmds/environment_cmds/create.js
@@ -48,7 +48,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .epilog(
       [

--- a/lib/cmds/space_cmds/environment_cmds/create.js
+++ b/lib/cmds/space_cmds/environment_cmds/create.js
@@ -2,6 +2,7 @@ const Promise = require('bluebird')
 const logging = require('../../../utils/log')
 const { handleAsyncError: handle } = require('../../../utils/async')
 const { createManagementClient } = require('../../../utils/contentful-clients')
+const { getHeadersFromOption } = require('../../../utils/headers')
 
 module.exports.command = 'create'
 
@@ -44,6 +45,11 @@ module.exports.builder = yargs => {
       describe: 'Contentful management API token',
       type: 'string'
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .epilog(
       [
         'See more at:',
@@ -58,13 +64,15 @@ async function environmentCreate({
   name,
   source,
   awaitProcessing,
-  environmentId
+  environmentId,
+  header
 }) {
   const { managementToken, activeSpaceId } = context
 
   const client = await createManagementClient({
     accessToken: managementToken,
-    feature: 'space-environment-create'
+    feature: 'space-environment-create',
+    headers: getHeadersFromOption(header)
   })
 
   const space = await client.getSpace(activeSpaceId)

--- a/lib/cmds/space_cmds/environment_cmds/delete.js
+++ b/lib/cmds/space_cmds/environment_cmds/delete.js
@@ -30,7 +30,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .epilog(
       [

--- a/lib/cmds/space_cmds/environment_cmds/delete.js
+++ b/lib/cmds/space_cmds/environment_cmds/delete.js
@@ -1,6 +1,7 @@
 const logging = require('../../../utils/log')
 const { handleAsyncError: handle } = require('../../../utils/async')
 const { createManagementClient } = require('../../../utils/contentful-clients')
+const { getHeadersFromOption } = require('../../../utils/headers')
 
 module.exports.command = 'delete'
 
@@ -26,6 +27,11 @@ module.exports.builder = yargs => {
       describe: 'Contentful management API token',
       type: 'string'
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .epilog(
       [
         'See more at:',
@@ -35,12 +41,13 @@ module.exports.builder = yargs => {
     )
 }
 
-async function environmentDelete({ context, environmentId }) {
+async function environmentDelete({ context, environmentId, header }) {
   const { managementToken, activeSpaceId } = context
 
   const client = await createManagementClient({
     accessToken: managementToken,
-    feature: 'space-environment-delete'
+    feature: 'space-environment-delete',
+    headers: getHeadersFromOption(header)
   })
 
   const space = await client.getSpace(activeSpaceId)

--- a/lib/cmds/space_cmds/environment_cmds/list.js
+++ b/lib/cmds/space_cmds/environment_cmds/list.js
@@ -27,7 +27,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .epilog(
       [

--- a/lib/cmds/space_cmds/environment_cmds/list.js
+++ b/lib/cmds/space_cmds/environment_cmds/list.js
@@ -2,6 +2,7 @@ const Table = require('cli-table3')
 
 const { handleAsyncError: handle } = require('../../../utils/async')
 const { createManagementClient } = require('../../../utils/contentful-clients')
+const { getHeadersFromOption } = require('../../../utils/headers')
 const { log } = require('../../../utils/log')
 const paginate = require('../../../utils/pagination')
 const { highlightStyle } = require('../../../utils/styles')
@@ -23,6 +24,11 @@ module.exports.builder = yargs => {
       describe: 'Contentful management API token',
       type: 'string'
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .epilog(
       [
         'See more at:',
@@ -34,12 +40,13 @@ module.exports.builder = yargs => {
 
 module.exports.aliases = ['ls']
 
-async function environmentList({ context }) {
+async function environmentList({ context, header }) {
   const { managementToken, activeSpaceId, activeEnvironmentId } = context
 
   const client = await createManagementClient({
     accessToken: managementToken,
-    feature: 'space-environment-list'
+    feature: 'space-environment-list',
+    headers: getHeadersFromOption(header)
   })
 
   const space = await client.getSpace(activeSpaceId)

--- a/lib/cmds/space_cmds/environment_cmds/use.js
+++ b/lib/cmds/space_cmds/environment_cmds/use.js
@@ -6,6 +6,7 @@ const { handleAsyncError: handle } = require('../../../utils/async')
 const { success } = require('../../../utils/log')
 const paginate = require('../../../utils/pagination')
 const { highlightStyle } = require('../../../utils/styles')
+const { getHeadersFromOption } = require('../../../utils/headers')
 
 module.exports.command = 'use'
 
@@ -28,6 +29,11 @@ module.exports.builder = yargs => {
       describe: 'Contentful management API token',
       type: 'string'
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .option('space-id', { alias: 's', type: 'string', describe: 'Space id' })
     .epilog('Copyright 2019 Contentful')
 }
@@ -44,12 +50,13 @@ function showSuccess(space, environment) {
   )
 }
 
-async function environmentUse({ context, environmentId }) {
+async function environmentUse({ context, environmentId, header }) {
   const { managementToken, activeSpaceId } = context
 
   const client = await createManagementClient({
     accessToken: managementToken,
-    feature: 'space-environment-use'
+    feature: 'space-environment-use',
+    headers: getHeadersFromOption(header)
   })
 
   const space = await client.getSpace(activeSpaceId)

--- a/lib/cmds/space_cmds/environment_cmds/use.js
+++ b/lib/cmds/space_cmds/environment_cmds/use.js
@@ -32,7 +32,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .option('space-id', { alias: 's', type: 'string', describe: 'Space id' })
     .epilog('Copyright 2019 Contentful')

--- a/lib/cmds/space_cmds/export.js
+++ b/lib/cmds/space_cmds/export.js
@@ -129,7 +129,7 @@ module.exports.builder = function (yargs) {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .config(
       'config',

--- a/lib/cmds/space_cmds/export.js
+++ b/lib/cmds/space_cmds/export.js
@@ -4,12 +4,13 @@ const { handleAsyncError: handle } = require('../../utils/async')
 const { proxyObjectToString } = require('../../utils/proxy')
 const emojic = require('emojic')
 const { version } = require('../../../package.json')
+const { getHeadersFromOption } = require('../../utils/headers')
 
 module.exports.command = 'export'
 
 module.exports.desc = 'export a space data to a json file'
 
-module.exports.builder = function(yargs) {
+module.exports.builder = function (yargs) {
   return yargs
     .option('space-id', {
       describe: 'ID of Space with source data',
@@ -125,6 +126,11 @@ module.exports.builder = function(yargs) {
       type: 'number',
       default: 10
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .config(
       'config',
       'An optional configuration JSON file containing all the options for a single run'
@@ -150,7 +156,8 @@ const exportSpace = async argv => {
     managementApplication: `contentful.cli/${version}`,
     managementFeature: feature,
     managementToken,
-    host
+    host,
+    headers: getHeadersFromOption(argv.header)
   }
 
   if (proxy) {

--- a/lib/cmds/space_cmds/generate.js
+++ b/lib/cmds/space_cmds/generate.js
@@ -2,7 +2,7 @@ module.exports.command = 'generate'
 
 module.exports.desc = 'Generate code for different tasks'
 
-module.exports.builder = function(yargs) {
+module.exports.builder = function (yargs) {
   return yargs
     .usage('')
     .commandDir('generate_cmds')

--- a/lib/cmds/space_cmds/generate_cmds/migration.js
+++ b/lib/cmds/space_cmds/generate_cmds/migration.js
@@ -9,6 +9,7 @@ const {
   createManagementClient: createClient
 } = require('../../../utils/contentful-clients')
 const fs = require('fs')
+const { getHeadersFromOption } = require('../../../utils/headers')
 
 const b = recast.types.builders
 
@@ -47,6 +48,11 @@ module.exports.builder = yargs => {
       alias: 'f',
       type: 'string'
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .epilog(
       [
         'See more at:',
@@ -58,7 +64,7 @@ module.exports.builder = yargs => {
 
 module.exports.aliases = ['m']
 
-const ctNameNeedsEscaping = function(ctId) {
+const ctNameNeedsEscaping = function (ctId) {
   const reservedWords = [
     'break',
     'case',
@@ -133,14 +139,14 @@ const ctNameNeedsEscaping = function(ctId) {
 
 module.exports.ctNameNeedsEscaping = ctNameNeedsEscaping
 
-const ctVariableEscape = function(ctId) {
+const ctVariableEscape = function (ctId) {
   const camelCased = camelCase(ctId)
   return ctNameNeedsEscaping(camelCased) ? `_${camelCased}` : camelCased
 }
 
 module.exports.ctVariableEscape = ctVariableEscape
 
-const wrapMigrationWithBase = function(blockStatement) {
+const wrapMigrationWithBase = function (blockStatement) {
   const migration = b.program([
     b.expressionStatement(
       b.assignmentExpression(
@@ -155,7 +161,7 @@ const wrapMigrationWithBase = function(blockStatement) {
 }
 module.exports.wrapMigrationWithBase = wrapMigrationWithBase
 
-const createCallChain = function(base, chain) {
+const createCallChain = function (base, chain) {
   if (chain.length === 0) {
     return base
   }
@@ -171,7 +177,7 @@ const createCallChain = function(base, chain) {
   )
 }
 
-const createContentType = function(ct) {
+const createContentType = function (ct) {
   const id = ct.sys.id
   const { name, description, displayField } = ct
   const chain = [
@@ -201,7 +207,7 @@ const createContentType = function(ct) {
 
 module.exports.createContentType = createContentType
 
-const createField = function(ctId, field) {
+const createField = function (ctId, field) {
   const fieldId = field.id
   const ctVariable = ctVariableEscape(ctId)
 
@@ -220,7 +226,7 @@ const createField = function(ctId, field) {
 
 module.exports.createField = createField
 
-const changeFieldControl = function(
+const changeFieldControl = function (
   ctId,
   fieldId,
   widgetNamespace,
@@ -250,7 +256,7 @@ const changeFieldControl = function(
   )
 }
 
-const getContentTypes = async function(environment, contentTypeId) {
+const getContentTypes = async function (environment, contentTypeId) {
   return contentTypeId
     ? [await environment.getContentType(contentTypeId)]
     : (await environment.getContentTypes()).items
@@ -260,7 +266,7 @@ module.exports.changeFieldControl = changeFieldControl
 
 module.exports.getContentTypes = getContentTypes
 
-const generateContentTypeMigration = async function(environment, contentType) {
+const generateContentTypeMigration = async function (environment, contentType) {
   log(`Creating migration for content type: '${contentType.sys.id}'`)
 
   const fieldCreators = contentType.fields.map(field => {
@@ -306,7 +312,7 @@ const generateContentTypeMigration = async function(environment, contentType) {
 
 module.exports.generateContentTypeMigration = generateContentTypeMigration
 
-const generateMigrationScript = async function(environment, contentTypes) {
+const generateMigrationScript = async function (environment, contentTypes) {
   const migrationContents = await Promise.all(
     _.map(contentTypes, async contentType => {
       return generateContentTypeMigration(environment, contentType)
@@ -323,21 +329,27 @@ const generateMigrationScript = async function(environment, contentTypes) {
 
 module.exports.generateMigrationScript = generateMigrationScript
 
-const generateFileName = function(spaceId, environmentId, contentTypeId) {
+const generateFileName = function (spaceId, environmentId, contentTypeId) {
   const contentTypePart = contentTypeId ? `-${contentTypeId}` : ''
 
   return `${spaceId}-${environmentId}${contentTypePart}-${Date.now()}.js`
 }
 
-const createManagementClient = function(managementToken) {
+const createManagementClient = function (managementToken, headers) {
   return createClient({
     accessToken: managementToken,
-    feature: 'migration-generate'
+    feature: 'migration-generate',
+    headers
   })
 }
 
-const getEnvironment = async function(managementToken, spaceId, environmentId) {
-  const client = await createManagementClient(managementToken)
+const getEnvironment = async function (
+  managementToken,
+  spaceId,
+  environmentId,
+  headers
+) {
+  const client = await createManagementClient(managementToken, headers)
   const space = await client.getSpace(spaceId)
   return space.getEnvironment(environmentId)
 }
@@ -347,7 +359,8 @@ module.exports.generateFileName = generateFileName
 async function generateMigration({
   context,
   filename: filenameFlag,
-  contentTypeId
+  contentTypeId,
+  header
 }) {
   const { managementToken, activeSpaceId, activeEnvironmentId } = context
 
@@ -358,7 +371,8 @@ async function generateMigration({
   const environment = await getEnvironment(
     managementToken,
     activeSpaceId,
-    activeEnvironmentId
+    activeEnvironmentId,
+    getHeadersFromOption(header)
   )
 
   log('Fetching content model')

--- a/lib/cmds/space_cmds/generate_cmds/migration.js
+++ b/lib/cmds/space_cmds/generate_cmds/migration.js
@@ -51,7 +51,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .epilog(
       [

--- a/lib/cmds/space_cmds/import.js
+++ b/lib/cmds/space_cmds/import.js
@@ -3,6 +3,7 @@ const { handleAsyncError: handle } = require('../../utils/async')
 const { proxyObjectToString } = require('../../utils/proxy')
 const { version } = require('../../../package.json')
 const { warning } = require('../../utils/log')
+const { getHeadersFromOption } = require('../../utils/headers')
 module.exports.command = 'import'
 
 module.exports.desc = 'import a space'
@@ -79,6 +80,11 @@ module.exports.builder = yargs => {
       type: 'number',
       default: 10
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .config(
       'config',
       'An optional configuration JSON file containing all the options for a single run'
@@ -108,7 +114,8 @@ const importSpace = async argv => {
     managementApplication: `contentful.cli/${version}`,
     managementFeature: feature,
     managementToken,
-    host
+    host,
+    headers: getHeadersFromOption(argv.header)
   }
 
   if (proxy) {

--- a/lib/cmds/space_cmds/import.js
+++ b/lib/cmds/space_cmds/import.js
@@ -83,7 +83,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .config(
       'config',

--- a/lib/cmds/space_cmds/list.js
+++ b/lib/cmds/space_cmds/list.js
@@ -2,6 +2,7 @@ const Table = require('cli-table3')
 
 const { handleAsyncError: handle } = require('../../utils/async')
 const { createManagementClient } = require('../../utils/contentful-clients')
+const { getHeadersFromOption } = require('../../utils/headers')
 const { log } = require('../../utils/log')
 const paginate = require('../../utils/pagination')
 const { highlightStyle } = require('../../utils/styles')
@@ -18,6 +19,11 @@ module.exports.builder = yargs => {
       describe: 'Contentful management API token',
       type: 'string'
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .epilog(
       [
         'See more at:',
@@ -29,12 +35,13 @@ module.exports.builder = yargs => {
 
 module.exports.aliases = ['ls']
 
-async function spaceList({ context }) {
+async function spaceList({ context, header }) {
   const { managementToken, activeSpaceId } = context
 
   const client = await createManagementClient({
     accessToken: managementToken,
-    feature: 'space-list'
+    feature: 'space-list',
+    headers: getHeadersFromOption(header)
   })
 
   const result = await paginate({ client, method: 'getSpaces' })

--- a/lib/cmds/space_cmds/list.js
+++ b/lib/cmds/space_cmds/list.js
@@ -22,7 +22,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .epilog(
       [

--- a/lib/cmds/space_cmds/migration.js
+++ b/lib/cmds/space_cmds/migration.js
@@ -57,7 +57,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .help('h')
     .alias('h', 'help')

--- a/lib/cmds/space_cmds/migration.js
+++ b/lib/cmds/space_cmds/migration.js
@@ -5,6 +5,7 @@ const { version } = require('../../../package.json')
 
 const path = require('path')
 const fs = require('fs')
+const { getHeadersFromOption } = require('../../utils/headers')
 
 module.exports.command = 'migration'
 
@@ -53,6 +54,11 @@ module.exports.builder = yargs => {
       describe: 'Reduce verbosity of information for the execution',
       default: false
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .help('h')
     .alias('h', 'help')
     .example('contentful space migration', '--space-id abcedef my-migration.js')
@@ -81,7 +87,8 @@ const migration = async argv => {
     managementApplication,
     managementFeature,
     accessToken: managementToken,
-    environmentId: activeEnvironmentId
+    environmentId: activeEnvironmentId,
+    headers: getHeadersFromOption(argv.header)
   }
   if (proxy) {
     // contentful-import and contentful-export

--- a/lib/cmds/space_cmds/seed.js
+++ b/lib/cmds/space_cmds/seed.js
@@ -43,7 +43,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .epilog('Copyright 2019 Contentful')
 }

--- a/lib/cmds/space_cmds/seed.js
+++ b/lib/cmds/space_cmds/seed.js
@@ -11,6 +11,7 @@ const { successEmoji } = require('../../utils/emojis')
 const { getLatestGitHubRelease } = require('../../utils/github')
 const { log, success } = require('../../utils/log')
 const { highlightStyle, warningStyle } = require('../../utils/styles')
+const { getHeadersFromOption } = require('../../utils/headers')
 
 module.exports.command = 'seed'
 module.exports.desc =
@@ -39,16 +40,28 @@ module.exports.builder = yargs => {
     .option('yes', {
       describe: 'Skip the confirmation question'
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .epilog('Copyright 2019 Contentful')
 }
 
-async function spaceSeed({ context, yes, template, feature = 'space-seed' }) {
+async function spaceSeed({
+  context,
+  yes,
+  template,
+  feature = 'space-seed',
+  header
+}) {
   const { managementToken, activeSpaceId, host, proxy, rawProxy } = context
   const client = await createManagementClient({
     accessToken: managementToken,
     feature,
     proxy,
-    rawProxy
+    rawProxy,
+    headers: getHeadersFromOption(header)
   })
 
   const space = await client.getSpace(activeSpaceId)

--- a/lib/cmds/space_cmds/use.js
+++ b/lib/cmds/space_cmds/use.js
@@ -26,7 +26,7 @@ module.exports.builder = yargs => {
     .option('header', {
       alias: 'H',
       type: 'string',
-      describe: 'Pass additional HTTP Header'
+      describe: 'Pass an additional HTTP Header'
     })
     .epilog('Copyright 2019 Contentful')
 }

--- a/lib/cmds/space_cmds/use.js
+++ b/lib/cmds/space_cmds/use.js
@@ -6,6 +6,7 @@ const { handleAsyncError: handle } = require('../../utils/async')
 const { success } = require('../../utils/log')
 const paginate = require('../../utils/pagination')
 const { highlightStyle } = require('../../utils/styles')
+const { getHeadersFromOption } = require('../../utils/headers')
 
 module.exports.command = 'use'
 
@@ -22,6 +23,11 @@ module.exports.builder = yargs => {
       describe: 'ID of the Space to use for other commands',
       type: 'string'
     })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass additional HTTP Header'
+    })
     .epilog('Copyright 2019 Contentful')
 }
 
@@ -35,12 +41,13 @@ function showSuccess(space, env) {
   )
 }
 
-async function spaceUse({ context, spaceId }) {
+async function spaceUse({ context, spaceId, header }) {
   const { managementToken, activeEnvironmentId } = context
 
   const client = await createManagementClient({
     accessToken: managementToken,
-    feature: 'space-use'
+    feature: 'space-use',
+    headers: getHeadersFromOption(header)
   })
 
   if (spaceId) {

--- a/lib/utils/headers.js
+++ b/lib/utils/headers.js
@@ -3,14 +3,18 @@
  * are ignored.
  *
  * @example
- * parseHeaderOption('Accept: Any')
+ * getHeadersFromOption('Accept: Any')
  * // -> {Accept: 'Any'}
  *
  * @example
- * parseHeaderOption(['Accept: Any', 'X-Version: 1'])
+ * getHeadersFromOption(['Accept: Any', 'X-Version: 1'])
  * // -> {Accept: 'Any', 'X-Version': '1'}
  */
 function getHeadersFromOption(value) {
+  if (!value) {
+    return {}
+  }
+
   const values = Array.isArray(value) ? value : [value]
 
   return values.reduce((headers, value) => {

--- a/lib/utils/headers.js
+++ b/lib/utils/headers.js
@@ -1,0 +1,36 @@
+/**
+ * Turn header option into an object. Invalid header values
+ * are ignored.
+ *
+ * @example
+ * parseHeaderOption('Accept: Any')
+ * // -> {Accept: 'Any'}
+ *
+ * @example
+ * parseHeaderOption(['Accept: Any', 'X-Version: 1'])
+ * // -> {Accept: 'Any', 'X-Version': '1'}
+ */
+function getHeadersFromOption(value) {
+  const values = Array.isArray(value) ? value : [value]
+
+  return values.reduce((headers, value) => {
+    value = value.trim()
+
+    const separatorIndex = value.indexOf(':')
+
+    // Invalid header format
+    if (separatorIndex === -1) {
+      return headers
+    }
+
+    const headerKey = value.slice(0, separatorIndex).trim()
+    const headerValue = value.slice(separatorIndex + 1).trim()
+
+    return {
+      ...headers,
+      [headerKey]: headerValue
+    }
+  }, {})
+}
+
+module.exports.getHeadersFromOption = getHeadersFromOption

--- a/test/integration/cmds/config/add.test.js
+++ b/test/integration/cmds/config/add.test.js
@@ -3,13 +3,13 @@ const fs = require('fs')
 const { join } = require('path')
 
 const bin = join(__dirname, './../../../../', 'bin')
-const TMP_CONFIG_FILE = join(fs.mkdtempSync('/tmp/add.test'), '.contentfulrc.json')
+const TMP_CONFIG_FILE = join(
+  fs.mkdtempSync('/tmp/add.test'),
+  '.contentfulrc.json'
+)
 
 const app = () => {
-  return nixt({ newlines: true })
-    .cwd(bin)
-    .base('./contentful.js ')
-    .clone()
+  return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
 }
 
 test('config add throws error when option as is empty', done => {
@@ -34,7 +34,7 @@ test('config add throws error when option mt is empty', done => {
     .end(done)
 })
 
-test('config add allows insecure', (done) => {
+test('config add allows insecure', done => {
   app()
     .env('CONTENTFUL_CONFIG_FILE', TMP_CONFIG_FILE)
     .run('config add --insecure=true')

--- a/test/integration/cmds/config/list.test.js
+++ b/test/integration/cmds/config/list.test.js
@@ -6,10 +6,7 @@ const { emptyContext } = require('../../../../lib/context')
 const bin = join(__dirname, './../../../../', 'bin')
 
 const app = () => {
-  return nixt({ newlines: true })
-    .cwd(bin)
-    .base('./contentful.js ')
-    .clone()
+  return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
 }
 
 let oldConfigContents = null

--- a/test/integration/cmds/extension/__snapshots__/create.test.js.snap
+++ b/test/integration/cmds/extension/__snapshots__/create.test.js.snap
@@ -19,6 +19,7 @@ Options:
   --sidebar                  Render the extension in the sidebar       [boolean]
   --installation-parameters  JSON string of installation parameter key-value
                              pairs                                      [string]
+  --header, -H               Pass additional HTTP Header                [string]
 
 Copyright 2019 Contentful"
 `;

--- a/test/integration/cmds/extension/__snapshots__/create.test.js.snap
+++ b/test/integration/cmds/extension/__snapshots__/create.test.js.snap
@@ -19,7 +19,7 @@ Options:
   --sidebar                  Render the extension in the sidebar       [boolean]
   --installation-parameters  JSON string of installation parameter key-value
                              pairs                                      [string]
-  --header, -H               Pass additional HTTP Header                [string]
+  --header, -H               Pass an additional HTTP Header             [string]
 
 Copyright 2019 Contentful"
 `;

--- a/test/integration/cmds/extension/__snapshots__/delete.test.js.snap
+++ b/test/integration/cmds/extension/__snapshots__/delete.test.js.snap
@@ -14,6 +14,7 @@ Options:
   --version                 Current version of the extension for optimistic
                             locking                                     [number]
   --force                   Force operation without explicit version   [boolean]
+  --header, -H              Pass additional HTTP Header                 [string]
 
 Copyright 2019 Contentful"
 `;

--- a/test/integration/cmds/extension/__snapshots__/delete.test.js.snap
+++ b/test/integration/cmds/extension/__snapshots__/delete.test.js.snap
@@ -14,7 +14,7 @@ Options:
   --version                 Current version of the extension for optimistic
                             locking                                     [number]
   --force                   Force operation without explicit version   [boolean]
-  --header, -H              Pass additional HTTP Header                 [string]
+  --header, -H              Pass an additional HTTP Header              [string]
 
 Copyright 2019 Contentful"
 `;

--- a/test/integration/cmds/extension/__snapshots__/update.test.js.snap
+++ b/test/integration/cmds/extension/__snapshots__/update.test.js.snap
@@ -22,7 +22,7 @@ Options:
   --force                    Force operation without explicit version  [boolean]
   --installation-parameters  JSON string of installation parameter key-value
                              pairs                                      [string]
-  --header, -H               Pass additional HTTP Header                [string]
+  --header, -H               Pass an additional HTTP Header             [string]
 
 Copyright 2019 Contentful"
 `;

--- a/test/integration/cmds/extension/__snapshots__/update.test.js.snap
+++ b/test/integration/cmds/extension/__snapshots__/update.test.js.snap
@@ -22,6 +22,7 @@ Options:
   --force                    Force operation without explicit version  [boolean]
   --installation-parameters  JSON string of installation parameter key-value
                              pairs                                      [string]
+  --header, -H               Pass additional HTTP Header                [string]
 
 Copyright 2019 Contentful"
 `;

--- a/test/integration/cmds/extension/create-update-delete.test.js
+++ b/test/integration/cmds/extension/create-update-delete.test.js
@@ -9,10 +9,7 @@ const configPath = resolve(__dirname, 'fixtures', 'sample-extension.json')
 const srcDocPath = resolve(__dirname, 'fixtures', 'sample-extension.html')
 
 const app = () => {
-  return nixt({ newlines: true })
-    .cwd(bin)
-    .base('./contentful.js ')
-    .clone()
+  return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
 }
 
 let space = null

--- a/test/integration/cmds/extension/create.test.js
+++ b/test/integration/cmds/extension/create.test.js
@@ -9,10 +9,7 @@ const configPath = resolve(__dirname, 'fixtures', 'sample-extension.json')
 const srcDocPath = resolve(__dirname, 'fixtures', 'sample-extension.html')
 
 const app = () => {
-  return nixt({ newlines: true })
-    .cwd(bin)
-    .base('./contentful.js ')
-    .clone()
+  return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
 }
 
 let space = null

--- a/test/integration/cmds/extension/delete.test.js
+++ b/test/integration/cmds/extension/delete.test.js
@@ -4,10 +4,7 @@ const { resolve } = require('path')
 const bin = resolve(__dirname, './../../../../', 'bin')
 
 const app = () => {
-  return nixt({ newlines: true })
-    .cwd(bin)
-    .base('./contentful.js ')
-    .clone()
+  return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
 }
 
 test('should print help message', done => {

--- a/test/integration/cmds/extension/update.test.js
+++ b/test/integration/cmds/extension/update.test.js
@@ -6,10 +6,7 @@ const bin = resolve(__dirname, './../../../../', 'bin')
 const configPath = resolve(__dirname, 'fixtures', 'sample-extension.json')
 
 const app = () => {
-  return nixt({ newlines: true })
-    .cwd(bin)
-    .base('./contentful.js ')
-    .clone()
+  return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
 }
 
 test('should print help message', done => {

--- a/test/integration/cmds/guide.test.js
+++ b/test/integration/cmds/guide.test.js
@@ -10,10 +10,7 @@ const bin = join(__dirname, './../../../', 'bin')
 const projectDirectoryName = 'ctf-cli-test-DELETE-ME'
 
 const app = () => {
-  return nixt({ newlines: true })
-    .cwd(bin)
-    .base('./contentful.js ')
-    .clone()
+  return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
 }
 
 const spacesToDelete = []

--- a/test/integration/cmds/login.test.js
+++ b/test/integration/cmds/login.test.js
@@ -5,10 +5,7 @@ const { initConfig } = require('../util')
 const bin = join(__dirname, './../../../', 'bin')
 
 const app = () => {
-  return nixt({ newlines: true })
-    .cwd(bin)
-    .base('./contentful.js ')
-    .clone()
+  return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
 }
 
 beforeAll(() => {

--- a/test/integration/cmds/logout.test.js
+++ b/test/integration/cmds/logout.test.js
@@ -5,10 +5,7 @@ const { initConfig } = require('../util')
 const bin = join(__dirname, './../../../', 'bin')
 
 const app = () => {
-  return nixt({ newlines: false })
-    .cwd(bin)
-    .base('./contentful.js ')
-    .clone()
+  return nixt({ newlines: false }).cwd(bin).base('./contentful.js ').clone()
 }
 
 beforeAll(() => {

--- a/test/integration/cmds/main.test.js
+++ b/test/integration/cmds/main.test.js
@@ -5,10 +5,7 @@ const packageVersion = require('../../../package.json').version
 const bin = join(__dirname, './../../../', 'bin')
 
 const app = () => {
-  return nixt({ newlines: true })
-    .cwd(bin)
-    .base('./contentful.js ')
-    .clone()
+  return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
 }
 
 test('should return code 1 when errors exist no args', done => {

--- a/test/integration/cmds/organization/__snapshots__/list.test.js.snap
+++ b/test/integration/cmds/organization/__snapshots__/list.test.js.snap
@@ -6,6 +6,7 @@ exports[`should print help message: help data is incorrect 1`] = `
 Options:
   -h, --help                Show help                                  [boolean]
   --management-token, --mt  Contentful management API token             [string]
+  --header, -H              Pass additional HTTP Header                 [string]
 
 See more at:
 https://github.com/contentful/contentful-cli/tree/master/docs/organization/list

--- a/test/integration/cmds/organization/__snapshots__/list.test.js.snap
+++ b/test/integration/cmds/organization/__snapshots__/list.test.js.snap
@@ -6,7 +6,7 @@ exports[`should print help message: help data is incorrect 1`] = `
 Options:
   -h, --help                Show help                                  [boolean]
   --management-token, --mt  Contentful management API token             [string]
-  --header, -H              Pass additional HTTP Header                 [string]
+  --header, -H              Pass an additional HTTP Header              [string]
 
 See more at:
 https://github.com/contentful/contentful-cli/tree/master/docs/organization/list

--- a/test/integration/cmds/organization/list.test.js
+++ b/test/integration/cmds/organization/list.test.js
@@ -6,10 +6,7 @@ const bin = join(__dirname, './../../../../', 'bin')
 const org = process.env.CLI_E2E_ORG_ID
 
 const app = () => {
-  return nixt({ newlines: true })
-    .cwd(bin)
-    .base('./contentful.js ')
-    .clone()
+  return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
 }
 
 beforeAll(() => {

--- a/test/integration/cmds/space/__snapshots__/create.test.js.snap
+++ b/test/integration/cmds/space/__snapshots__/create.test.js.snap
@@ -14,6 +14,7 @@ Options:
   --default-locale, -l      The default locale of the new space         [string]
   --use, -u                 Use the created space as default space when the
                             --space-id is skipped.                     [boolean]
+  --header, -H              Pass additional HTTP Header                 [string]
 
 Copyright 2019 Contentful
 Missing required argument: name"
@@ -33,6 +34,7 @@ Options:
   --default-locale, -l      The default locale of the new space         [string]
   --use, -u                 Use the created space as default space when the
                             --space-id is skipped.                     [boolean]
+  --header, -H              Pass additional HTTP Header                 [string]
 
 Copyright 2019 Contentful"
 `;

--- a/test/integration/cmds/space/__snapshots__/create.test.js.snap
+++ b/test/integration/cmds/space/__snapshots__/create.test.js.snap
@@ -14,7 +14,7 @@ Options:
   --default-locale, -l      The default locale of the new space         [string]
   --use, -u                 Use the created space as default space when the
                             --space-id is skipped.                     [boolean]
-  --header, -H              Pass additional HTTP Header                 [string]
+  --header, -H              Pass an additional HTTP Header              [string]
 
 Copyright 2019 Contentful
 Missing required argument: name"
@@ -34,7 +34,7 @@ Options:
   --default-locale, -l      The default locale of the new space         [string]
   --use, -u                 Use the created space as default space when the
                             --space-id is skipped.                     [boolean]
-  --header, -H              Pass additional HTTP Header                 [string]
+  --header, -H              Pass an additional HTTP Header              [string]
 
 Copyright 2019 Contentful"
 `;

--- a/test/integration/cmds/space/__snapshots__/delete.test.js.snap
+++ b/test/integration/cmds/space/__snapshots__/delete.test.js.snap
@@ -8,6 +8,7 @@ Options:
   --space-id, -s            ID of the space to delete                 [required]
   --management-token, --mt  Contentful management API token             [string]
   --yes                     Skip the confirmation question
+  --header, -H              Pass additional HTTP Header                 [string]
 
 Copyright 2019 Contentful
 Missing required argument: space-id"
@@ -21,6 +22,7 @@ Options:
   --space-id, -s            ID of the space to delete                 [required]
   --management-token, --mt  Contentful management API token             [string]
   --yes                     Skip the confirmation question
+  --header, -H              Pass additional HTTP Header                 [string]
 
 Copyright 2019 Contentful"
 `;

--- a/test/integration/cmds/space/__snapshots__/delete.test.js.snap
+++ b/test/integration/cmds/space/__snapshots__/delete.test.js.snap
@@ -8,7 +8,7 @@ Options:
   --space-id, -s            ID of the space to delete                 [required]
   --management-token, --mt  Contentful management API token             [string]
   --yes                     Skip the confirmation question
-  --header, -H              Pass additional HTTP Header                 [string]
+  --header, -H              Pass an additional HTTP Header              [string]
 
 Copyright 2019 Contentful
 Missing required argument: space-id"
@@ -22,7 +22,7 @@ Options:
   --space-id, -s            ID of the space to delete                 [required]
   --management-token, --mt  Contentful management API token             [string]
   --yes                     Skip the confirmation question
-  --header, -H              Pass additional HTTP Header                 [string]
+  --header, -H              Pass an additional HTTP Header              [string]
 
 Copyright 2019 Contentful"
 `;

--- a/test/integration/cmds/space/__snapshots__/import.test.js.snap
+++ b/test/integration/cmds/space/__snapshots__/import.test.js.snap
@@ -26,6 +26,7 @@ Options:
                                                        [number] [default: 20000]
   --retry-limit              How many times to retry before an operation fails
                                                           [number] [default: 10]
+  --header, -H               Pass additional HTTP Header                [string]
   --config                   An optional configuration JSON file containing all
                              the options for a single run
 
@@ -59,6 +60,7 @@ Options:
                                                        [number] [default: 20000]
   --retry-limit              How many times to retry before an operation fails
                                                           [number] [default: 10]
+  --header, -H               Pass additional HTTP Header                [string]
   --config                   An optional configuration JSON file containing all
                              the options for a single run
 

--- a/test/integration/cmds/space/__snapshots__/import.test.js.snap
+++ b/test/integration/cmds/space/__snapshots__/import.test.js.snap
@@ -26,7 +26,7 @@ Options:
                                                        [number] [default: 20000]
   --retry-limit              How many times to retry before an operation fails
                                                           [number] [default: 10]
-  --header, -H               Pass additional HTTP Header                [string]
+  --header, -H               Pass an additional HTTP Header             [string]
   --config                   An optional configuration JSON file containing all
                              the options for a single run
 
@@ -60,7 +60,7 @@ Options:
                                                        [number] [default: 20000]
   --retry-limit              How many times to retry before an operation fails
                                                           [number] [default: 10]
-  --header, -H               Pass additional HTTP Header                [string]
+  --header, -H               Pass an additional HTTP Header             [string]
   --config                   An optional configuration JSON file containing all
                              the options for a single run
 

--- a/test/integration/cmds/space/__snapshots__/list.test.js.snap
+++ b/test/integration/cmds/space/__snapshots__/list.test.js.snap
@@ -6,7 +6,7 @@ exports[`should print help message: help data is incorrect 1`] = `
 Options:
   -h, --help                Show help                                  [boolean]
   --management-token, --mt  Contentful management API token             [string]
-  --header, -H              Pass additional HTTP Header                 [string]
+  --header, -H              Pass an additional HTTP Header              [string]
 
 See more at:
 https://github.com/contentful/contentful-cli/tree/master/docs/space/list

--- a/test/integration/cmds/space/__snapshots__/list.test.js.snap
+++ b/test/integration/cmds/space/__snapshots__/list.test.js.snap
@@ -6,6 +6,7 @@ exports[`should print help message: help data is incorrect 1`] = `
 Options:
   -h, --help                Show help                                  [boolean]
   --management-token, --mt  Contentful management API token             [string]
+  --header, -H              Pass additional HTTP Header                 [string]
 
 See more at:
 https://github.com/contentful/contentful-cli/tree/master/docs/space/list

--- a/test/integration/cmds/space/create.test.js
+++ b/test/integration/cmds/space/create.test.js
@@ -5,10 +5,7 @@ const { initConfig, deleteSpaces, extractSpaceId } = require('../../util')
 const bin = join(__dirname, './../../../../', 'bin')
 
 const app = () => {
-  return nixt({ newlines: true })
-    .cwd(bin)
-    .base('./contentful.js ')
-    .clone()
+  return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
 }
 
 var spacesToDelete = []

--- a/test/integration/cmds/space/delete.test.js
+++ b/test/integration/cmds/space/delete.test.js
@@ -9,10 +9,7 @@ const bin = join(__dirname, './../../../../', 'bin')
 const org = process.env.CLI_E2E_ORG_ID
 
 const app = () => {
-  return nixt({ newlines: true })
-    .cwd(bin)
-    .base('./contentful.js ')
-    .clone()
+  return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
 }
 
 var space = null

--- a/test/integration/cmds/space/environment/__snapshots__/create.test.js.snap
+++ b/test/integration/cmds/space/environment/__snapshots__/create.test.js.snap
@@ -16,7 +16,7 @@ Options:
   --await-processing, -w    Wait until the environment is processed and ready
                                                       [boolean] [default: false]
   --management-token, --mt  Contentful management API token             [string]
-  --header, -H              Pass additional HTTP Header                 [string]
+  --header, -H              Pass an additional HTTP Header              [string]
 
 See more at:
 https://github.com/contentful/contentful-cli/tree/master/docs/space/environment/
@@ -39,7 +39,7 @@ Options:
   --await-processing, -w    Wait until the environment is processed and ready
                                                       [boolean] [default: false]
   --management-token, --mt  Contentful management API token             [string]
-  --header, -H              Pass additional HTTP Header                 [string]
+  --header, -H              Pass an additional HTTP Header              [string]
 
 See more at:
 https://github.com/contentful/contentful-cli/tree/master/docs/space/environment/

--- a/test/integration/cmds/space/environment/__snapshots__/create.test.js.snap
+++ b/test/integration/cmds/space/environment/__snapshots__/create.test.js.snap
@@ -16,6 +16,7 @@ Options:
   --await-processing, -w    Wait until the environment is processed and ready
                                                       [boolean] [default: false]
   --management-token, --mt  Contentful management API token             [string]
+  --header, -H              Pass additional HTTP Header                 [string]
 
 See more at:
 https://github.com/contentful/contentful-cli/tree/master/docs/space/environment/
@@ -38,6 +39,7 @@ Options:
   --await-processing, -w    Wait until the environment is processed and ready
                                                       [boolean] [default: false]
   --management-token, --mt  Contentful management API token             [string]
+  --header, -H              Pass additional HTTP Header                 [string]
 
 See more at:
 https://github.com/contentful/contentful-cli/tree/master/docs/space/environment/

--- a/test/integration/cmds/space/environment/create-list-delete.test.js
+++ b/test/integration/cmds/space/environment/create-list-delete.test.js
@@ -20,7 +20,7 @@ beforeAll(async () => {
 
 afterAll(() => {
   return deleteSpaces(spacesToDelete)
-})
+}, 10000)
 
 test('should create, list and delete environment', done => {
   function createEnvironment() {

--- a/test/integration/cmds/space/environment/create-list-delete.test.js
+++ b/test/integration/cmds/space/environment/create-list-delete.test.js
@@ -5,10 +5,7 @@ const { initConfig, deleteSpaces, createSimpleSpace } = require('../../../util')
 const bin = join(__dirname, './../../../../../', 'bin')
 
 const app = () => {
-  return nixt({ newlines: true })
-    .cwd(bin)
-    .base('./contentful.js ')
-    .clone()
+  return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
 }
 
 const org = process.env.CLI_E2E_ORG_ID

--- a/test/integration/cmds/space/environment/create.test.js
+++ b/test/integration/cmds/space/environment/create.test.js
@@ -20,7 +20,7 @@ beforeAll(async () => {
 
 afterAll(() => {
   return deleteSpaces(spacesToDelete)
-})
+}, 10000)
 
 test('should exit 1 when no args', done => {
   app()

--- a/test/integration/cmds/space/environment/create.test.js
+++ b/test/integration/cmds/space/environment/create.test.js
@@ -5,10 +5,7 @@ const { initConfig, deleteSpaces, createSimpleSpace } = require('../../../util')
 const bin = join(__dirname, './../../../../../', 'bin')
 
 const app = () => {
-  return nixt({ newlines: true })
-    .cwd(bin)
-    .base('./contentful.js ')
-    .clone()
+  return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
 }
 
 const org = process.env.CLI_E2E_ORG_ID

--- a/test/integration/cmds/space/help.test.js
+++ b/test/integration/cmds/space/help.test.js
@@ -4,10 +4,7 @@ const { join } = require('path')
 const bin = join(__dirname, './../../../../', 'bin')
 
 const app = () => {
-  return nixt({ newlines: true })
-    .cwd(bin)
-    .base('./contentful.js ')
-    .clone()
+  return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
 }
 
 test('should print help message', done => {

--- a/test/integration/cmds/space/import.test.js
+++ b/test/integration/cmds/space/import.test.js
@@ -29,7 +29,7 @@ beforeAll(async () => {
 })
 afterAll(() => {
   return deleteSpaces(spacesToDelete)
-})
+}, 10000)
 
 test('should print help message', done => {
   app()

--- a/test/integration/cmds/space/list.test.js
+++ b/test/integration/cmds/space/list.test.js
@@ -21,7 +21,7 @@ beforeAll(async () => {
 })
 afterAll(() => {
   return deleteSpaces(spacesToDelete)
-})
+}, 10000)
 
 test('should print help message', done => {
   app()

--- a/test/integration/cmds/space/list.test.js
+++ b/test/integration/cmds/space/list.test.js
@@ -6,10 +6,7 @@ const bin = join(__dirname, './../../../../', 'bin')
 const org = process.env.CLI_E2E_ORG_ID
 
 const app = () => {
-  return nixt({ newlines: true })
-    .cwd(bin)
-    .base('./contentful.js ')
-    .clone()
+  return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
 }
 
 var space = null

--- a/test/proxy/server.js
+++ b/test/proxy/server.js
@@ -22,15 +22,19 @@ function onConnection(req, socket) {
 
   const serverUrl = url.parse('https://' + req.url)
 
-  const srvSocket = net.connect(serverUrl.port, serverUrl.hostname, function() {
-    socket.write(
-      'HTTP/1.1 200 Connection Established\r\n' +
-        'Proxy-agent: Node-Proxy\r\n' +
-        '\r\n'
-    )
-    srvSocket.pipe(socket)
-    socket.pipe(srvSocket)
-  })
+  const srvSocket = net.connect(
+    serverUrl.port,
+    serverUrl.hostname,
+    function () {
+      socket.write(
+        'HTTP/1.1 200 Connection Established\r\n' +
+          'Proxy-agent: Node-Proxy\r\n' +
+          '\r\n'
+      )
+      srvSocket.pipe(socket)
+      socket.pipe(srvSocket)
+    }
+  )
 }
 
 const handler = (resolve, reject) => err => {

--- a/test/unit/cmds/extension_cmds/update.test.js
+++ b/test/unit/cmds/extension_cmds/update.test.js
@@ -55,7 +55,7 @@ beforeEach(() => {
       getEnvironment: async () => ({
         getUiExtension: async () => {
           const extension = { ...basicExtension }
-          extension.update = function() {
+          extension.update = function () {
             return updateStub(this)
           }
           return extension

--- a/test/unit/cmds/space_cmds/export.test.js
+++ b/test/unit/cmds/space_cmds/export.test.js
@@ -35,7 +35,8 @@ test('it should pass all args to contentful-export', async () => {
     environmentId: 'master',
     managementToken: 'managementToken',
     spaceId: 'spaceId',
-    host: 'api.contentful.com'
+    host: 'api.contentful.com',
+    headers: {}
   }
   expect(contentfulExport.mock.calls[0][0]).toEqual(result)
   expect(contentfulExport).toHaveBeenCalledTimes(1)

--- a/test/unit/cmds/space_cmds/generate_cmds/migration.test.js
+++ b/test/unit/cmds/space_cmds/generate_cmds/migration.test.js
@@ -53,20 +53,20 @@ const editorInterface = {
   ]
 }
 
-const EditorInterfaceNotFoundErrorMock = function() {
+const EditorInterfaceNotFoundErrorMock = function () {
   this.name = 'NotFound'
 }
 
 const environmentMock = {
-  getContentTypes: function() {
+  getContentTypes: function () {
     return {
       items: [simpleContentType]
     }
   },
-  getContentType: function() {
+  getContentType: function () {
     return simpleContentType
   },
-  getEditorInterfaceForContentType: function(ctId) {
+  getEditorInterfaceForContentType: function (ctId) {
     if (ctId === 'foo') {
       return editorInterface
     } else {

--- a/test/unit/cmds/space_cmds/import.test.js
+++ b/test/unit/cmds/space_cmds/import.test.js
@@ -28,7 +28,8 @@ test('it should pass all args to contentful-import', async () => {
     managementToken: 'managementToken',
     spaceId: 'spaceId',
     environmentId: undefined,
-    host: undefined
+    host: undefined,
+    headers: {}
   }
   expect(contentfulImport.mock.calls[0][0]).toEqual(result)
   expect(contentfulImport).toHaveBeenCalledTimes(1)

--- a/test/unit/cmds/space_cmds/migration.test.js
+++ b/test/unit/cmds/space_cmds/migration.test.js
@@ -24,7 +24,8 @@ test('it should pass all args to the migration', async () => {
     ...stubArgv,
     spaceId: 'spaceId',
     environmentId: 'master',
-    accessToken: 'managementToken'
+    accessToken: 'managementToken',
+    headers: {}
   }
 
   expect(runMigration.mock.calls[0][0]).toEqual(result)

--- a/test/unit/utils/fs.test.js
+++ b/test/unit/utils/fs.test.js
@@ -7,7 +7,7 @@ const accessP = promisify(fs.access)
 const rmdirP = promisify(fs.rmdir)
 const mkdirP = promisify(fs.mkdir)
 
-test('ensureDir creates dir if it does not exist', async function() {
+test('ensureDir creates dir if it does not exist', async function () {
   const dirPath = '/tmp/i_hope_this_path_does_not_exist'
 
   try {
@@ -27,7 +27,7 @@ test('ensureDir creates dir if it does not exist', async function() {
   }
 })
 
-test('ensureDir does not break if called multiple times', async function() {
+test('ensureDir does not break if called multiple times', async function () {
   const dirPath = '/tmp/some_random_path_for_tests'
 
   try {
@@ -49,7 +49,7 @@ test('ensureDir does not break if called multiple times', async function() {
   }
 })
 
-test('ensureDir rethrows on no ENOENT errors', async function() {
+test('ensureDir rethrows on no ENOENT errors', async function () {
   const parentDir = '/tmp/path_with_no_read_rights'
   const dirPath = '/tmp/path_with_no_read_rights/foo'
 

--- a/test/unit/utils/headers.test.js
+++ b/test/unit/utils/headers.test.js
@@ -1,5 +1,9 @@
 const { getHeadersFromOption } = require('../../../lib/utils/headers')
 
+test('getHeadersFromOption returns empty object when value is undefined', () => {
+  expect(getHeadersFromOption(undefined)).toEqual({})
+})
+
 test('getHeadersFromOption accepts single or multiple values', () => {
   expect(getHeadersFromOption('Accept: Any')).toEqual({ Accept: 'Any' })
   expect(getHeadersFromOption(['Accept: Any', 'X-Version: 1'])).toEqual({

--- a/test/unit/utils/headers.test.js
+++ b/test/unit/utils/headers.test.js
@@ -1,0 +1,31 @@
+const { getHeadersFromOption } = require('../../../lib/utils/headers')
+
+test('getHeadersFromOption accepts single or multiple values', () => {
+  expect(getHeadersFromOption('Accept: Any')).toEqual({ Accept: 'Any' })
+  expect(getHeadersFromOption(['Accept: Any', 'X-Version: 1'])).toEqual({
+    Accept: 'Any',
+    'X-Version': '1'
+  })
+})
+
+test('getHeadersFromOption ignores invalid headers', () => {
+  expect(
+    getHeadersFromOption(['Accept: Any', 'X-Version: 1', 'invalid'])
+  ).toEqual({
+    Accept: 'Any',
+    'X-Version': '1'
+  })
+})
+
+test('getHeadersFromOption trims spacing around keys & values', () => {
+  expect(
+    getHeadersFromOption([
+      '  Accept:   Any   ',
+      '   X-Version   :1 ',
+      'invalid'
+    ])
+  ).toEqual({
+    Accept: 'Any',
+    'X-Version': '1'
+  })
+})

--- a/test/unit/utils/markdown.test.js
+++ b/test/unit/utils/markdown.test.js
@@ -1,6 +1,6 @@
 const markdown = require('../../../lib/utils/markdown')
 
-test('headings are rendered in terminal', function() {
+test('headings are rendered in terminal', function () {
   const md = `
 # H1
 ## H2
@@ -25,7 +25,7 @@ Alt-H2
 `)
 })
 
-test('urls are rendered in terminal', function() {
+test('urls are rendered in terminal', function () {
   const md = `
 [I'm an inline-style link](https://www.google.com)
 http://www.example.com
@@ -38,7 +38,7 @@ http://www.example.com
 `)
 })
 
-test('inline code is rendered in terminal', function() {
+test('inline code is rendered in terminal', function () {
   const inlineCode = `
 Inline \`code\` has \`back-ticks around\` it.
   `
@@ -47,7 +47,7 @@ Inline \`code\` has \`back-ticks around\` it.
   expect(res).toContain(`Inline code has back-ticks around it.`)
 })
 
-test('code blocks are rendered in terminal', function() {
+test('code blocks are rendered in terminal', function () {
   const inlineCode = `
 \`\`\`python
 s = "Python syntax highlighting"

--- a/test/unit/utils/middlewares.test.js
+++ b/test/unit/utils/middlewares.test.js
@@ -105,7 +105,10 @@ test('useFlagsIfAvailable set activeEnvironmentId (from context)', async () => {
   })
   const result = await buildContext({})
   expect(result).toEqual({
-    context: { ...defaults.context, activeEnvironmentId: 'activeEnvironmentId' }
+    context: {
+      ...defaults.context,
+      activeEnvironmentId: 'activeEnvironmentId'
+    }
   })
 })
 


### PR DESCRIPTION
## Summary

Support passing additional HTTP Headers to (most) commands. For example:

```sh
contentful export -H "x-contentful-enable-alpha-feature: my-feature" ...args
```


## Description

Added `--header/-H` option to the following command namespaces:

- Content Type
- Extension
- Organization
- Space

A header value should be `"key: value"` format. Whitespaces are allowed but will be trimmed. A value that doesn't follow the aforementioned format will be ignored silently. 

## Motivation and Context

Enabling users to pass additional headers can be useful in general but especially when testing out alpha features (e.g. part of EAP program)

## Todos

- [x] Support `--header/-H` option in necessary commands
- [ ] Update docs. Is this supposed to be done manually?
- [x] Fix & add more tests if necessary

P.S. Sorry about the changes set. Most of it caused by running `npm run lint -- --fix`. I had to adjust Prettier rules that are mostly ignored throughout the code to get a smaller changeset (was 133 files before 🤯 )

