### PR TITLE
chore: release experimental branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,3 +106,8 @@ workflows:
             - linux
             # - audit
             - osx
+          filters:
+            branches:
+              only:
+                - master
+                - experimental

--- a/package.json
+++ b/package.json
@@ -149,6 +149,14 @@
     ]
   },
   "release": {
+    "branches": [
+      "master",
+      {
+        "name": "experimental",
+        "channel": "experimental",
+        "prerelease": true
+      }
+    ],
     "plugins": [
       [
         "@semantic-release/commit-analyzer",


### PR DESCRIPTION
## Summary

In order to properly use other experimental versions of our packages, we need a new channel here too.