### PR TITLE
Update marked to 2.0.0 and fix a failing test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10480,9 +10480,9 @@
       }
     },
     "marked": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.7.tgz",
-      "integrity": "sha512-No11hFYcXr/zkBvL6qFmAp1z6BKY3zqLMHny/JN/ey+al7qwCM2+CMBL9BOgqMxZU36fz4cCWfn2poWIf7QRXA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.0.tgz",
+      "integrity": "sha512-NqRSh2+LlN2NInpqTQnS614Y/3NkVMFFU6sJlRFEpxJ/LHuK/qJECH7/fXZjk4VZstPW/Pevjil/VtSONsLc7Q=="
     },
     "marked-terminal": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "inquirer-select-directory": "^1.2.0",
     "listr": "^0.14.1",
     "lodash": "^4.17.15",
-    "marked": "^1.1.1",
+    "marked": "^2.0.0",
     "mkdirp": "^1.0.3",
     "mz": "^2.6.0",
     "open": "^7.0.3",

--- a/test/unit/utils/markdown.test.js
+++ b/test/unit/utils/markdown.test.js
@@ -26,10 +26,9 @@ Alt-H2
 })
 
 test('urls are rendered in terminal', function () {
-  const md = `
-[I'm an inline-style link](https://www.google.com)
+  const md = `[I'm an inline-style link](https://www.google.com)
 http://www.example.com
-  `
+`
 
   const res = markdown(md)
   expect(res).toBe(`I’m an inline-style link (https://www.google.com)


### PR DESCRIPTION
## Summary

Fixes the failing test from Dependabot's automatic dependency bump for `marked`.

## Motivation and Context

The dependency version bump is necessary because there is a security vulnerability which is fixed in version 2.0.0. A failing test was preventing the automatically created PR from being merged.