### PR TITLE
feat(env-creation): allow for custom timeout value

### DIFF
--- a/lib/cmds/space_cmds/environment_cmds/create.js
+++ b/lib/cmds/space_cmds/environment_cmds/create.js
@@ -36,8 +36,9 @@ module.exports.builder = yargs => {
     })
     .option('await-processing', {
       alias: 'w',
-      describe: 'Wait until the environment is processed and ready',
-      type: 'boolean',
+      describe:
+        'Wait until the environment is processed and ready. Specify timeout in miliseconds.',
+      type: ['boolean', 'number'],
       default: false
     })
     .option('management-token', {
@@ -88,13 +89,16 @@ async function environmentCreate({
 
   logging.success(
     `Successfully created environment ${environment.name} (${
-      environment.sys.id
+    environment.sys.id
     }) ${source ? `with source ${source}` : ''}`
   )
 
   if (awaitProcessing) {
     const DELAY = 3000
-    const MAX_NUMBER_OF_TRIES = 10
+    let MAX_NUMBER_OF_TRIES = 10
+    if (typeof awaitProcessing === 'number') {
+      MAX_NUMBER_OF_TRIES = Math.ceil(awaitProcessing / DELAY)
+    }
     let count = 0
 
     logging.log('Waiting for processing...')


### PR DESCRIPTION
`--await-processing` for environment creation times out for environments that take longer than 30 seconds which is the hard coded default. This PR introduces the option to provide a custom timeout value in milliseconds.

**TODO**
* Default value for using `--await-processing` actually changes to `false` with this change which would be a breaking change. This has to be adjusted.
* Add test

An alternative to this PR could be to change the default value.