### PR TITLE
feat(env-creation): increase retry default for env processing check

### DIFF
--- a/lib/cmds/space_cmds/environment_cmds/create.js
+++ b/lib/cmds/space_cmds/environment_cmds/create.js
@@ -94,7 +94,7 @@ async function environmentCreate({
 
   if (awaitProcessing) {
     const DELAY = 3000
-    const MAX_NUMBER_OF_TRIES = 10
+    const MAX_NUMBER_OF_TRIES = 100
     let count = 0
 
     logging.log('Waiting for processing...')


### PR DESCRIPTION
To account for environments for which creation takes longer than 30 seconds, we increase the number of retries that environment processing status is checked.