### PR TITLE
feat(env-creation): add processing-timeout option

### DIFF
--- a/docs/space/environment/create/README.md
+++ b/docs/space/environment/create/README.md
@@ -6,11 +6,18 @@ Create a new Environment within a Space. You have to supply an id for the Enviro
 
 ```
 Options:
-  --environment-id, -e   Id of the environment to create                   [required]
-  --name, -n             Name of the environment to create
-  --source, -src         ID of the source environment to create the new environment from
-  --space-id             ID of the space the environment will belong to    [string]
-  --await-processing, -w Wait until the environment is processed and ready [boolean] [default: false]
+  --environment-id, -e      Id of the environment to create           [required]
+  --name, -n                Name of the environment to create         [required]
+  --source, --src           ID of the source environment to create the new
+                            environment from                            [string]
+  --space-id, -s            ID of the space that the environment will belong to
+                                                                        [string]
+  --await-processing, -w    Wait until the environment is processed and ready
+                                                      [boolean] [default: false]
+  --processing-timeout, -t  Await processing times out after specified number of
+                            minutes                        [number] [default: 5]
+  --management-token, --mt  Contentful management API token             [string]
+  --header, -H              Pass an additional HTTP Header              [string]
 ```
 
 ### Example

--- a/docs/space/environment/create/README.md
+++ b/docs/space/environment/create/README.md
@@ -15,7 +15,8 @@ Options:
   --await-processing, -w    Wait until the environment is processed and ready
                                                       [boolean] [default: false]
   --processing-timeout, -t  Await processing times out after specified number of
-                            minutes                        [number] [default: 5]
+                            minutes (only is applied if await-processing is set)
+                                                           [number] [default: 5]
   --management-token, --mt  Contentful management API token             [string]
   --header, -H              Pass an additional HTTP Header              [string]
 ```

--- a/lib/cmds/space_cmds/environment_cmds/create.js
+++ b/lib/cmds/space_cmds/environment_cmds/create.js
@@ -56,7 +56,6 @@ module.exports.builder = yargs => {
       type: 'string',
       describe: 'Pass an additional HTTP Header'
     })
-    .implies('processing-timeout', 'await-processing')
     .epilog(
       [
         'See more at:',
@@ -68,8 +67,8 @@ module.exports.builder = yargs => {
 
 async function checkAwaitProcessing(space, environment, timeoutInMinutes) {
   const DELAY = 3000
-  const timeoutInMiliseconds = Math.ceil(timeoutInMinutes * 60 * 1000)
-  const MAX_NUMBER_OF_TRIES = Math.ceil(timeoutInMiliseconds / DELAY)
+  const timeoutInMilliseconds = Math.ceil(timeoutInMinutes * 60 * 1000)
+  const MAX_NUMBER_OF_TRIES = Math.ceil(timeoutInMilliseconds / DELAY)
   let count = 0
 
   logging.log('Waiting for processing...')
@@ -124,7 +123,7 @@ async function environmentCreate({
 
   logging.success(
     `Successfully created environment ${environment.name} (${
-    environment.sys.id
+      environment.sys.id
     }) ${source ? `with source ${source}` : ''}`
   )
 

--- a/lib/cmds/space_cmds/environment_cmds/create.js
+++ b/lib/cmds/space_cmds/environment_cmds/create.js
@@ -40,6 +40,12 @@ module.exports.builder = yargs => {
       type: 'boolean',
       default: false
     })
+    .option('processing-timeout', {
+      alias: 't',
+      describe: 'Await processing times out after specified number of minutes',
+      type: 'number',
+      default: 5
+    })
     .option('management-token', {
       alias: 'mt',
       describe: 'Contentful management API token',
@@ -50,6 +56,7 @@ module.exports.builder = yargs => {
       type: 'string',
       describe: 'Pass an additional HTTP Header'
     })
+    .implies('processing-timeout', 'await-processing')
     .epilog(
       [
         'See more at:',
@@ -59,11 +66,40 @@ module.exports.builder = yargs => {
     )
 }
 
+async function checkAwaitProcessing(space, environment, timeoutInMinutes) {
+  const DELAY = 3000
+  const timeoutInMiliseconds = Math.ceil(timeoutInMinutes * 60 * 1000)
+  const MAX_NUMBER_OF_TRIES = Math.ceil(timeoutInMiliseconds / DELAY)
+  let count = 0
+
+  logging.log('Waiting for processing...')
+
+  while (count < MAX_NUMBER_OF_TRIES) {
+    const status = (await space.getEnvironment(environment.sys.id)).sys.status
+      .sys.id
+
+    if (status === 'ready' || status === 'failed') {
+      if (status === 'ready') {
+        logging.success(
+          `Successfully processed new environment ${environment.name} (${environment.sys.id})`
+        )
+      } else {
+        logging.error('Environment creation failed')
+      }
+      break
+    }
+
+    await Promise.delay(DELAY)
+    count++
+  }
+}
+
 async function environmentCreate({
   context,
   name,
   source,
   awaitProcessing,
+  processingTimeout,
   environmentId,
   header
 }) {
@@ -88,35 +124,12 @@ async function environmentCreate({
 
   logging.success(
     `Successfully created environment ${environment.name} (${
-      environment.sys.id
+    environment.sys.id
     }) ${source ? `with source ${source}` : ''}`
   )
 
   if (awaitProcessing) {
-    const DELAY = 3000
-    const MAX_NUMBER_OF_TRIES = 100
-    let count = 0
-
-    logging.log('Waiting for processing...')
-
-    while (count < MAX_NUMBER_OF_TRIES) {
-      const status = (await space.getEnvironment(environment.sys.id)).sys.status
-        .sys.id
-
-      if (status === 'ready' || status === 'failed') {
-        if (status === 'ready') {
-          logging.success(
-            `Successfully processed new environment ${environment.name} (${environment.sys.id})`
-          )
-        } else {
-          logging.error('Environment creation failed')
-        }
-        break
-      }
-
-      await Promise.delay(DELAY)
-      count++
-    }
+    checkAwaitProcessing(space, environment, processingTimeout)
   }
 
   return environment

--- a/lib/cmds/space_cmds/environment_cmds/create.js
+++ b/lib/cmds/space_cmds/environment_cmds/create.js
@@ -42,7 +42,8 @@ module.exports.builder = yargs => {
     })
     .option('processing-timeout', {
       alias: 't',
-      describe: 'Await processing times out after specified number of minutes',
+      describe:
+        'Await processing times out after specified number of minutes (only is applied if await-processing is set)',
       type: 'number',
       default: 5
     })
@@ -123,7 +124,7 @@ async function environmentCreate({
 
   logging.success(
     `Successfully created environment ${environment.name} (${
-      environment.sys.id
+    environment.sys.id
     }) ${source ? `with source ${source}` : ''}`
   )
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:jest": "jest test/integration/cmds/**",
     "test:integration": "NODE_ENV=test concurrently \"npm:run-talkback-proxy\" \"npm:test:jest\" --success first --kill-others",
     "test:integration:ci": "NODE_ENV=test concurrently \"npm:run-talkback-proxy\" \"npm:test:jest -- --runInBand\" --success first --kill-others",
-    "test:integration:update": "NODE_ENV=test concurrently \"npm:run-talkback-proxy\" \"npm:test:jest -- --updateSnapshot\" --success first --kill-others",
+    "test:integration:update": "NODE_ENV=test concurrently \"npm:run-talkback-proxy\" \"npm:test:jest -- --updateSnapshot --runInBand\" --success first --kill-others",
     "test:e2e": "cross-env jest --testPathPattern=test/e2e --verbose",
     "test:simulate-ci": "trevor",
     "precommit": "npm run prettier:write && lint-staged",

--- a/test/integration/cmds/space/environment/__snapshots__/create.test.js.snap
+++ b/test/integration/cmds/space/environment/__snapshots__/create.test.js.snap
@@ -15,6 +15,8 @@ Options:
                                                                         [string]
   --await-processing, -w    Wait until the environment is processed and ready
                                                       [boolean] [default: false]
+  --processing-timeout, -t  Await processing times out after specified number of
+                            minutes                        [number] [default: 5]
   --management-token, --mt  Contentful management API token             [string]
   --header, -H              Pass an additional HTTP Header              [string]
 
@@ -38,6 +40,8 @@ Options:
                                                                         [string]
   --await-processing, -w    Wait until the environment is processed and ready
                                                       [boolean] [default: false]
+  --processing-timeout, -t  Await processing times out after specified number of
+                            minutes                        [number] [default: 5]
   --management-token, --mt  Contentful management API token             [string]
   --header, -H              Pass an additional HTTP Header              [string]
 

--- a/test/integration/cmds/space/environment/__snapshots__/create.test.js.snap
+++ b/test/integration/cmds/space/environment/__snapshots__/create.test.js.snap
@@ -16,7 +16,8 @@ Options:
   --await-processing, -w    Wait until the environment is processed and ready
                                                       [boolean] [default: false]
   --processing-timeout, -t  Await processing times out after specified number of
-                            minutes                        [number] [default: 5]
+                            minutes (only is applied if await-processing is set)
+                                                           [number] [default: 5]
   --management-token, --mt  Contentful management API token             [string]
   --header, -H              Pass an additional HTTP Header              [string]
 
@@ -41,7 +42,8 @@ Options:
   --await-processing, -w    Wait until the environment is processed and ready
                                                       [boolean] [default: false]
   --processing-timeout, -t  Await processing times out after specified number of
-                            minutes                        [number] [default: 5]
+                            minutes (only is applied if await-processing is set)
+                                                           [number] [default: 5]
   --management-token, --mt  Contentful management API token             [string]
   --header, -H              Pass an additional HTTP Header              [string]
 


### PR DESCRIPTION
Add optional option to provide a specified timeout in minutes for `--await-processing` upon environment creation.

**Open Issues**
- We should add a test [here](https://github.com/contentful/contentful-cli/blob/master/test/unit/cmds/space_cmds/environment_cmds/create.test.js) that checks that `environmentCreate` triggers `checkAwaitProcessing` with the correct parameters. How to mock that correctly?
- Snapshot tests behave flaky locally.