### PR TITLE
fix(env-creation): awaiting processing timeout message

### DIFF
--- a/lib/cmds/space_cmds/environment_cmds/create.js
+++ b/lib/cmds/space_cmds/environment_cmds/create.js
@@ -124,12 +124,20 @@ async function environmentCreate({
 
   logging.success(
     `Successfully created environment ${environment.name} (${
-    environment.sys.id
+      environment.sys.id
     }) ${source ? `with source ${source}` : ''}`
   )
 
   if (awaitProcessing) {
-    checkAwaitProcessing(space, environment, processingTimeout)
+    await checkAwaitProcessing(space, environment, processingTimeout)
+    const status = (await space.getEnvironment(environment.sys.id)).sys.status
+      .sys.id
+
+    if (!(status === 'ready' || status === 'failed')) {
+      logging.log(
+        `The environment is not ready and the awaiting processing time is over`
+      )
+    }
   }
 
   return environment


### PR DESCRIPTION
Informe users when environment processing is not ready and the awaiting time is over
