### PR TITLE
add `e` alias to `environment-id` flag

### DIFF
--- a/lib/cmds/content-type_cmds/get.js
+++ b/lib/cmds/content-type_cmds/get.js
@@ -19,7 +19,11 @@ module.exports.builder = yargs => {
       type: 'string',
       describe: 'Contentful management API token'
     })
-    .option('environment-id', { type: 'string', describe: 'Environment id' })
+    .option("environment-id", {
+      alias: "e",
+      type: "string",
+      describe: "Environment id",
+    })
     .option('header', {
       alias: 'H',
       type: 'string',


### PR DESCRIPTION
allows `-e` flag in `contentful ct get` command as it is in `contentful ct ls`

## Summary
`-e` alias for `--environment-id` is available for `contentful content-type ls` but not for `contentful content-type get`

## Description

I'd like to be able to use the `-e` alias for `environment-id` in the `contentful ct get` command as it is with the `contentful ct ls` command.

### Example

- invalid:
`contentful ct get -s ********* -e sandbox --id *********`

- valid:
`contentful ct ls -s ********* -e sandbox`

- valid:
`contentful ct get -s ********* --environment-id sandbox --id *********`


## Motivation and Context

it will bring consistency to `contentful ct` / `contentful content-type` and expedite the command.

## Help Command output

```
→ contentful ct get -h
 ct get

Show a content type

Options:
  -h, --help                Show help                                  [boolean]
  --id                      Content Type id                  [string] [required]
  --space-id, -s            Space id                                    [string]
  --management-token, --mt  Contentful management API token             [string]
  --environment-id          Environment id                              [string]

Copyright 2019 Contentful
```
```
→ contentful ct ls -h 
 ct list

List your content types

Options:
  -h, --help                Show help                                  [boolean]
  --space-id, -s            Space id                                    [string]
  --management-token, --mt  Contentful management API token             [string]
  --environment-id, -e      Environment ID you want to interact with. Defaults
                            to the current active environment.          [string]

Copyright 2019 Contentful
```