### PR TITLE
chore(dependabot): ignore dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,26 @@ updates:
       timezone: UTC
     open-pull-requests-limit: 10
     ignore:
+    - dependency-name: find-up # Pure ESM package. Remove from ignore when ESM is supported
+      versions:
+        - ">=6.0.0"
+    - dependency-name: execa # Pure ESM package. Remove from ignore when ESM is supported
+      versions:
+        - ">=6.0.0"
+    - dependency-name: chalk # Pure ESM package. Remove from ignore when ESM is supported
+      versions:
+        - ">=5.0.0"
+    - dependency-name: strip-ansi # Pure ESM package. Remove from ignore when ESM is supported
+      versions:
+        - ">=7.0.0"
+    - dependency-name: wrap-ansi # Pure ESM package. Remove from ignore when ESM is supported
+      versions:
+        - ">=8.0.0"
+    - dependency-name: marked # Pure ESM package. Remove from ignore when ESM is supported
+      versions:
+        - ">=4.0.0"
+
     - dependency-name: jest
-    - dependency-name: strip-ansi
-    - dependency-name: marked
     - dependency-name: yargs
     - dependency-name: husky
       versions:


### PR DESCRIPTION
Adds dependencies to dependabot ignore list

### Reason

All ignored dependencies are now pure ESM packages. This PR lets dependabot ignore them for now in order to declutter the open pull requests. However, we shoud consider a rewrite to ESM or making changes to support pure ESM packages (e.g. like described [here](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c)).
