### PR TITLE
feat(params): Add delivery-token param to export cmd [ZEND-1938]

### DIFF
--- a/lib/cmds/space_cmds/export.js
+++ b/lib/cmds/space_cmds/export.js
@@ -25,6 +25,11 @@ module.exports.builder = function (yargs) {
       describe: 'Contentful management API token',
       type: 'string'
     })
+    .option('delivery-token', {
+      alias: 'dt',
+      describe: 'Contentful delivery API token',
+      type: 'string'
+    })
     .option('export-dir', {
       describe:
         'Defines the path for storing the export json file (default path is the current directory)',

--- a/test/unit/cmds/space_cmds/export.test.js
+++ b/test/unit/cmds/space_cmds/export.test.js
@@ -17,6 +17,7 @@ test('it should pass all args to contentful-export', async () => {
       host: 'api.contentful.com',
       managementToken: 'managementToken'
     },
+    deliveryToken: 'deliveryToken',
     includeDrafts: false,
     includeArchived: false,
     skipRoles: false,


### PR DESCRIPTION
Add delivery-token param to the param list for the export command. We already support this command but it was not listed so far.