### PR TITLE
chore: upgrade marked

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,10 +24,6 @@ updates:
     - dependency-name: wrap-ansi # Pure ESM package. Remove from ignore when ESM is supported
       versions:
         - ">=8.0.0"
-    - dependency-name: marked # Pure ESM package. Remove from ignore when ESM is supported
-      versions:
-        - ">=4.0.0"
-
     - dependency-name: jest
     - dependency-name: yargs
     - dependency-name: husky

--- a/lib/utils/markdown.js
+++ b/lib/utils/markdown.js
@@ -1,4 +1,4 @@
-const marked = require('marked')
+const { marked } = require('marked')
 const chalk = require('chalk')
 
 const {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "inquirer-select-directory": "^1.2.0",
         "listr": "^0.14.1",
         "lodash": "^4.17.15",
-        "marked": "^3.0.8",
+        "marked": "^4.0.12",
         "mkdirp": "^1.0.3",
         "mz": "^2.6.0",
         "open": "^8.0.5",
@@ -12140,11 +12140,11 @@
       }
     },
     "node_modules/marked": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
-      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
         "node": ">= 12"
@@ -17756,18 +17756,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release/node_modules/marked": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
-      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
-      "dev": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/semantic-release/node_modules/marked-terminal": {
@@ -29931,9 +29919,9 @@
       }
     },
     "marked": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
-      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw=="
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ=="
     },
     "meow": {
       "version": "8.1.2",
@@ -34040,12 +34028,6 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
-        },
-        "marked": {
-          "version": "4.0.10",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
-          "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
-          "dev": true
         },
         "marked-terminal": {
           "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "inquirer-select-directory": "^1.2.0",
     "listr": "^0.14.1",
     "lodash": "^4.17.15",
-    "marked": "^3.0.8",
+    "marked": "^4.0.12",
     "mkdirp": "^1.0.3",
     "mz": "^2.6.0",
     "open": "^8.0.5",


### PR DESCRIPTION
### Open issues
- ~Since version 4, marked is a pure ESM package and therefore supposed to be ignored for now: https://github.com/contentful/contentful-cli/blob/master/.github/dependabot.yml#L27 This PR is blocked until we have added support for pure ESM packages.~
- ~Align on reasoning for https://github.com/contentful/contentful-cli/pull/1266~
- ~See also: https://github.com/contentful/contentful-cli/issues/1337~

Above issues are resolved, it's fine to use v4 with commonjs. See also [here](https://github.com/markedjs/marked/issues/2380#issuecomment-1030133024)