### PR TITLE
feat(accesstoken_cmds): Add silent output for accesstoken list

### DIFF
--- a/docs/space/README.md
+++ b/docs/space/README.md
@@ -3,6 +3,7 @@
 ## Available subcommands:
 
 - [use](./use) - Remember a Space to skip the `--space-id` option in subsequent commands
+- [accesstoken](./accesstoken) - List and create access tokens
 - [list](./list) - List all Spaces you have access to
 - [create](./create) - Create a new Space
 - [seed](./seed) - Seed a predefined template to a Space

--- a/docs/space/accesstoken/create.md
+++ b/docs/space/accesstoken/create.md
@@ -1,0 +1,23 @@
+# Contentful CLI - `space accesstoken create` command
+
+Create a new delivery access token.
+
+## Usage
+
+```
+Usage: contentful accesstoken create --name 'Your token name' --description 'Your token description'
+
+Options:
+  --space-id          ID of Space with source data                [string]
+  --management-token  Contentful management API token             [string]
+  --name              Name of the Token to create                 [string]
+  --description       Description giving more detailed
+                      information about the usage of the Token    [string]
+  --silent            Suppress command output                     [boolean]
+```
+
+## Example
+
+```sh
+contentful accesstoken create --name 'Your token name' --description 'Your token description'
+```

--- a/docs/space/accesstoken/list.md
+++ b/docs/space/accesstoken/list.md
@@ -1,0 +1,20 @@
+# Contentful CLI - `space accesstoken list` command
+
+List your delivery access tokens in a tabular format.
+
+## Usage
+
+```
+Usage: contentful space acccesstoken list
+
+Options:
+  --space-id          ID of Space with source data                                          [string]
+  --management-token  Contentful management API token                                       [string]
+  --silent            Returns the list in raw JSON format instead of a formatted table      [boolean]
+```
+
+## Example
+
+```sh
+contentful space acccesstoken list
+```

--- a/lib/cmds/space_cmds/accesstoken_cmds/list.js
+++ b/lib/cmds/space_cmds/accesstoken_cmds/list.js
@@ -27,13 +27,22 @@ module.exports.builder = yargs => {
       type: 'string',
       describe: 'Pass an additional HTTP Header'
     })
+    .option('silent', {
+      describe:
+        'Returns the list in raw JSON format instead of a formatted table',
+      default: false
+    })
     .usage('Usage: contentful space accesstoken list')
     .epilog(epilog)
 }
 
 module.exports.aliases = ['ls']
 
-async function accessTokenList({ context, header }) {
+module.exports.accessTokenList = async function accessTokenList({
+  context,
+  header,
+  silent
+}) {
   const { managementToken, activeSpaceId } = context
 
   const client = await createManagementClient({
@@ -45,17 +54,25 @@ async function accessTokenList({ context, header }) {
   const space = await client.getSpace(activeSpaceId)
   const result = await paginate({ client: space, method: 'getApiKeys' })
 
-  const tokens = result.items.sort((a, b) => a.name.localeCompare(b.name))
+  if (silent) {
+    delete result.total
+    delete result.limit
+    delete result.skip
+    delete result.sys
+    log(JSON.stringify(result, null, 2))
+  } else {
+    const tokens = result.items.sort((a, b) => a.name.localeCompare(b.name))
 
-  const table = new Table({
-    head: ['Name', 'Description', 'Token']
-  })
+    const table = new Table({
+      head: ['Name', 'Description', 'Token']
+    })
 
-  tokens.forEach(token => {
-    table.push([token.name, token.description, token.accessToken])
-  })
+    tokens.forEach(token => {
+      table.push([token.name, token.description, token.accessToken])
+    })
 
-  log(table.toString())
+    log(table.toString())
+  }
 }
 
-module.exports.handler = handle(accessTokenList)
+module.exports.handler = handle(module.exports.accessTokenList)

--- a/test/unit/cmds/space_cmds/accesstoken_cmds/list.test.js
+++ b/test/unit/cmds/space_cmds/accesstoken_cmds/list.test.js
@@ -1,0 +1,72 @@
+const {
+  accessTokenList
+} = require('../../../../../lib/cmds/space_cmds/accesstoken_cmds/list')
+const { getContext } = require('../../../../../lib/context')
+const {
+  createManagementClient
+} = require('../../../../../lib/utils/contentful-clients')
+jest.mock('../../../../../lib/utils/log')
+jest.mock('../../../../../lib/context')
+jest.mock('../../../../../lib/utils/contentful-clients')
+
+const { log } = require('../../../../../lib/utils/log')
+jest.mock('../../../../../lib/utils/log')
+
+const accessTokenData = {
+  items: [
+    {
+      name: 'DemoSpace',
+      description: 'API key',
+      accessToken: 'DemoAccessToken123456789'
+    }
+  ]
+}
+
+let getAcccessTokensStub
+
+const fakeClient = {
+  getSpace: async () => ({
+    getApiKeys: getAcccessTokensStub
+  })
+}
+
+describe('space accesstoken list', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  beforeEach(() => {
+    getAcccessTokensStub = jest.fn().mockResolvedValue(accessTokenData)
+
+    createManagementClient.mockResolvedValue(fakeClient)
+
+    getContext.mockResolvedValue({
+      managementToken: 'mockedToken'
+    })
+  })
+
+  it('can pretty print console output', async () => {
+    await accessTokenList({
+      context: {
+        activeSpaceId: 'someSpaceID'
+      }
+    })
+    expect(createManagementClient).toHaveBeenCalledTimes(1)
+    expect(getAcccessTokensStub).toHaveBeenCalledTimes(1)
+    expect(log.mock.calls[0][0]).toContain(accessTokenData.items[0].name)
+  })
+
+  it('can silently output to sdtout', async () => {
+    await accessTokenList({
+      context: {
+        activeSpaceId: 'someSpaceID'
+      },
+      silent: true
+    })
+    expect(createManagementClient).toHaveBeenCalledTimes(1)
+    expect(getAcccessTokensStub).toHaveBeenCalledTimes(1)
+    expect(log.mock.calls[0][0]).toContain(
+      JSON.stringify(accessTokenData, null, 2)
+    )
+  })
+})


### PR DESCRIPTION
Add a `silent` parameter to the `contentful space accesstoken list` command in order to print out the raw JSON result.

[Feature request](https://github.com/contentful/contentful-cli/issues/1476)