### PR TITLE
feat(accesstoken): Add environment flag to accesstoken create command

### DIFF
--- a/docs/space/accesstoken/create.md
+++ b/docs/space/accesstoken/create.md
@@ -13,6 +13,9 @@ Options:
   --name              Name of the Token to create                 [string]
   --description       Description giving more detailed
                       information about the usage of the Token    [string]
+  --environment -e    Environment the access token will
+                      have access to. Defaults to "master" if
+                      omitted                                     [string]
   --silent            Suppress command output                     [boolean]
 ```
 

--- a/lib/cmds/space_cmds/accesstoken_cmds/create.js
+++ b/lib/cmds/space_cmds/accesstoken_cmds/create.js
@@ -25,6 +25,11 @@ module.exports.builder = yargs => {
       describe:
         'Description giving more detailed information about the usage of the Token'
     })
+    .option('environment', {
+      alias: 'e',
+      describe:
+        'Environment the access token will have access to. Defaults to "master" if omitted'
+    })
     .option('management-token', {
       alias: 'mt',
       describe: 'Contentful management API token',
@@ -49,6 +54,7 @@ async function accessTokenCreate(argv) {
     name,
     description,
     silent,
+    environment,
     feature = 'space-access_token-create'
   } = argv
   const { managementToken, activeSpaceId } = context
@@ -75,10 +81,24 @@ async function accessTokenCreate(argv) {
     return accessToken
   }
 
-  accessToken = await space.createApiKey({
+  let accessTokenPayload = {
     name,
     description
-  })
+  }
+
+  if (environment && environment.length > 0) {
+    accessTokenPayload.environments = [
+      {
+        sys: {
+          type: 'Link',
+          linkType: 'Environment',
+          id: environment
+        }
+      }
+    ]
+  }
+
+  accessToken = await space.createApiKey(accessTokenPayload)
 
   if (!silent) {
     success(

--- a/test/unit/cmds/space_cmds/accesstoken_cmds/create.test.js
+++ b/test/unit/cmds/space_cmds/accesstoken_cmds/create.test.js
@@ -50,6 +50,39 @@ test('create new access token', async () => {
   expect(createApiKeyStub.mock.calls[0][0]).toEqual(mockedAccessTokenData)
 })
 
+test('create new access token with specified environment', async () => {
+  const specificEnvironmentAccessToken = {
+    name: 'access token name',
+    description: 'some example description',
+    environments: [
+      {
+        sys: {
+          id: 'test-env',
+          linkType: 'Environment',
+          type: 'Link'
+        }
+      }
+    ]
+  }
+
+  getApiKeysStub.mockResolvedValue({
+    items: []
+  })
+  const result = await accessTokenCreate({
+    ...mockedAccessTokenData,
+    environment: 'test-env',
+    context: {
+      activeSpaceId: 'some-space-id'
+    }
+  })
+  expect(result).toBeTruthy()
+  expect(createManagementClient).toHaveBeenCalledTimes(1)
+  expect(createApiKeyStub).toHaveBeenCalledTimes(1)
+  expect(createApiKeyStub.mock.calls[0][0]).toEqual(
+    specificEnvironmentAccessToken
+  )
+})
+
 test('return existing access token', async () => {
   getApiKeysStub.mockResolvedValue({
     items: [mockedAccessTokenData]


### PR DESCRIPTION
Add environment flag to `space accesstoken create` command to specify which environment the accesstoken will have access to. Defaults to master if omitted. 
[Feature request](https://github.com/contentful/contentful-cli/issues/1390)