### PR TITLE
fix: add defaultLocale as option to space create command

### DIFF
--- a/lib/cmds/space_cmds/create.ts
+++ b/lib/cmds/space_cmds/create.ts
@@ -44,6 +44,11 @@ export const builder = (yargs: Argv) => {
       describe:
         'Confirm space creation without prompt, be aware this may result in extra monthly charges depend on your subscription'
     })
+    .option('default-locale', {
+      alias: 'l',
+      describe: 'The default locale of the new space',
+      type: 'string'
+    })
     .option('use', {
       alias: 'u',
       describe:
@@ -65,6 +70,7 @@ interface Context {
 interface SpaceCreateProps {
   context: Context
   name: string
+  defaultLocale?: string
   yes?: boolean
   use?: boolean
   feature?: string
@@ -73,7 +79,15 @@ interface SpaceCreateProps {
 }
 
 export const spaceCreate = async function (argv: SpaceCreateProps) {
-  const { context, name, yes, use, header, feature = 'space-create' } = argv
+  const {
+    context,
+    name,
+    defaultLocale,
+    yes,
+    use,
+    header,
+    feature = 'space-create'
+  } = argv
 
   const { managementToken } = context
   let { organizationId = '' } = argv
@@ -141,7 +155,8 @@ the Pricing page: https://www.contentful.com/pricing/?faq_category=payments&faq=
 
   const space = await client.createSpace(
     {
-      name
+      name,
+      defaultLocale
     },
     organizationId
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "command-exists": "^1.2.7",
         "contentful-export": "^7.17.16",
         "contentful-import": "^8.3.2",
-        "contentful-management": "^10.0.0",
+        "contentful-management": "^10.12.1",
         "contentful-migration": "^4.8.0",
         "emojic": "^1.1.11",
         "execa": "^5.0.0",
@@ -8018,9 +8018,9 @@
       }
     },
     "node_modules/contentful-management": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.8.0.tgz",
-      "integrity": "sha512-K+q9tbw8SULf5fg+tfLxE4WhHO+1iXyxjdGfy+hv9m1pwJFLhvBmudHOAA1jX1RnqayDUuRqjs/4otVb9cs/KA==",
+      "version": "10.12.1",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.12.1.tgz",
+      "integrity": "sha512-yquFhWa9l/K4fZ6SpGxUwJTZXmrFhDN1Qw8y2Mk17heucCp1tlKxOfOhoxljQM25r/IKlfI2rNTTZmJQx8+xFw==",
       "dependencies": {
         "@types/json-patch": "0.0.30",
         "axios": "^0.27.1",
@@ -28534,9 +28534,9 @@
       }
     },
     "contentful-management": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.8.0.tgz",
-      "integrity": "sha512-K+q9tbw8SULf5fg+tfLxE4WhHO+1iXyxjdGfy+hv9m1pwJFLhvBmudHOAA1jX1RnqayDUuRqjs/4otVb9cs/KA==",
+      "version": "10.12.1",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.12.1.tgz",
+      "integrity": "sha512-yquFhWa9l/K4fZ6SpGxUwJTZXmrFhDN1Qw8y2Mk17heucCp1tlKxOfOhoxljQM25r/IKlfI2rNTTZmJQx8+xFw==",
       "requires": {
         "@types/json-patch": "0.0.30",
         "axios": "^0.27.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "command-exists": "^1.2.7",
     "contentful-export": "^7.17.16",
     "contentful-import": "^8.3.2",
-    "contentful-management": "^10.0.0",
+    "contentful-management": "^10.12.1",
     "contentful-migration": "^4.8.0",
     "emojic": "^1.1.11",
     "execa": "^5.0.0",

--- a/test/integration/cmds/space/__snapshots__/create.test.js.snap
+++ b/test/integration/cmds/space/__snapshots__/create.test.js.snap
@@ -11,6 +11,7 @@ Options:
   --yes, -y                 Confirm space creation without prompt, be aware this
                             may result in extra monthly charges depend on your
                             subscription
+  --default-locale, -l      The default locale of the new space         [string]
   --use, -u                 Use the created space as default space when the
                             --space-id is skipped.                     [boolean]
   --header, -H              Pass an additional HTTP Header              [string]
@@ -30,6 +31,7 @@ Options:
   --yes, -y                 Confirm space creation without prompt, be aware this
                             may result in extra monthly charges depend on your
                             subscription
+  --default-locale, -l      The default locale of the new space         [string]
   --use, -u                 Use the created space as default space when the
                             --space-id is skipped.                     [boolean]
   --header, -H              Pass an additional HTTP Header              [string]


### PR DESCRIPTION
## Summary

Contentful management js lib types was not showing `defaultLocale` as an available option in `createSpace` method.
That led to removing it in #1583  See https://github.com/contentful/contentful-cli/pull/1583#discussion_r957541315

This PR adds the options back `contentful space create --default-locale`
