### PR TITLE
chore: clean up login command messaging structure

### DIFF
--- a/.contentfulrc.json
+++ b/.contentfulrc.json
@@ -1,4 +1,0 @@
-{
-  "managementToken": "blahblah12234553",
-  "activeSpaceId": "89898989"
-}

--- a/lib/cmds/init.ts
+++ b/lib/cmds/init.ts
@@ -27,10 +27,7 @@ export const init = async () => {
   let managementToken = context.managementToken
 
   if (!context.managementToken) {
-    managementToken = await login({
-      context,
-      managementToken
-    })
+    managementToken = await login({ context })
   }
 
   if (!managementToken) return

--- a/lib/cmds/login.ts
+++ b/lib/cmds/login.ts
@@ -54,12 +54,13 @@ export const login = async ({
     token = managementTokenFlag
   } else {
     if (managementToken) {
+      console.log(`You're already logged in!`)
+      await tokenInfo()
       console.log(
-        `You're already logged in! to logout type: ${chalk.green(
-          'contentful'
-        )} ${chalk.magenta('logout')}`
+        `To logout, type: ${chalk.green('contentful')} ${chalk.magenta(
+          'logout'
+        )}\n`
       )
-      tokenInfo()
       return managementToken
     }
 

--- a/lib/cmds/login.ts
+++ b/lib/cmds/login.ts
@@ -2,13 +2,12 @@ import open from 'open'
 import inquirer from 'inquirer'
 import chalk from 'chalk'
 
-import { getConfigPath, setContext, storeRuntimeConfig } from '../context'
+import { setContext, storeRuntimeConfig } from '../context'
 import { confirmation } from '../utils/actions'
 import { handleAsyncError as handle } from '../utils/async'
-import { log } from '../utils/log'
-import { highlightStyle, codeStyle, pathStyle } from '../utils/styles'
-import { frame } from '../utils/text'
+import { highlightStyle, pathStyle } from '../utils/styles'
 import { Argv } from 'yargs'
+import { tokenInfo } from '../utils/token-info'
 
 const APP_ID =
   '9f86a1d54f3d6f85c159468f5919d6e5d27716b3ed68fd01bd534e3dea2df864'
@@ -55,28 +54,25 @@ export const login = async ({
     token = managementTokenFlag
   } else {
     if (managementToken) {
-      log()
-      log(
-        `Looks like you already stored a management token on your system. ${chalk.dim(
-          `(Located at ${await getConfigPath()})`
-        )}`
+      console.log(
+        `You're already logged in! to logout type: ${chalk.green(
+          'contentful'
+        )} ${chalk.magenta('logout')}`
       )
-      log(frame(`Your management token: ${managementToken}`))
-      log(`Maybe you want to ${codeStyle('contentful logout')}?`)
+      tokenInfo()
       return managementToken
     }
 
-    log(
+    console.log(
       `A browser window will open where you will log in (or sign up if you don’t have an account), authorize this CLI tool and paste your ${highlightStyle(
         'CMA token'
-      )} here:`
+      )} here:\n`
     )
-    log()
 
-    const confirmed = await confirmation('Continue login through the browser?')
+    const confirmed = await confirmation('Continue login on the browser?')
 
     if (!confirmed) {
-      log(
+      console.log(
         chalk.red('Aborted!'),
         'please login to use Contentful CLI features!',
         `\nUsage: ${chalk.green('contentful')} ${chalk.cyan('login')}`
@@ -90,7 +86,7 @@ export const login = async ({
         wait: false
       })
     } else {
-      log(
+      console.log(
         `Unable to open your browser automatically. Please open the following URI in your browser:\n\n${pathStyle(
           oAuthURL
         )}\n\n`
@@ -100,6 +96,7 @@ export const login = async ({
     const tokenAnswer = await inquirer.prompt([
       {
         type: 'password',
+        mask: true,
         name: 'managementToken',
         message: 'Paste your token here:',
         validate: val => /^[a-zA-Z0-9_-]{43,64}$/i.test(val.trim()) // token is 43 to 64 characters and accepts lower/uppercase characters plus `-` and `_`
@@ -112,17 +109,11 @@ export const login = async ({
   await setContext({
     managementToken: token
   })
-  await storeRuntimeConfig()
-  log()
-  log(
-    `Great! Your ${highlightStyle(
-      'CMA token'
-    )} is now stored on your system. ${chalk.dim(
-      `(Located at ${await getConfigPath()})`
-    )}`
-  )
-  log(`You can always run ${codeStyle('contentful logout')} to remove it.`)
 
+  await storeRuntimeConfig()
+
+  console.log(`\n${chalk.green('Great!')} You've successfully logged in!`)
+  tokenInfo()
   return token
 }
 

--- a/lib/utils/async.ts
+++ b/lib/utils/async.ts
@@ -1,13 +1,13 @@
-const { logError } = require('./log')
+import { Argv } from 'yargs'
+import { logError } from './log'
 
-module.exports.handleAsyncError =
-  (asyncFn, errorHandler = logError) =>
-  argv => {
-    return asyncFn(argv).catch(error => {
+export const handleAsyncError =
+  (asyncFn: (params: any) => Promise<unknown>, errorHandler = logError) =>
+  (argv: Argv) =>
+    asyncFn(argv).catch((error: Error) => {
       errorHandler(error)
       // Since the error got catched to allow async commands in yargs
       // and we can't throw to avoid unresolved promise rejections,
       // we manually exit here with exit code 1
       process.exit(1)
     })
-  }

--- a/lib/utils/token-info.ts
+++ b/lib/utils/token-info.ts
@@ -1,0 +1,25 @@
+import boxen from 'boxen'
+import chalk from 'chalk'
+import { getConfigPath, getContext } from '../context'
+
+export const tokenInfo = async () => {
+  const configFilePath = await getConfigPath()
+  const { managementToken } = await getContext()
+
+  if (!configFilePath || !managementToken) return
+
+  console.log(
+    boxen(
+      `Your management token: ${chalk.dim(
+        managementToken
+      )} \nStored at: ${chalk.dim(configFilePath)}`,
+      {
+        padding: 1,
+        borderStyle: 'round',
+        textAlignment: 'left',
+        margin: { left: 0, right: 0, top: 0.5, bottom: 0.5 },
+        borderColor: 'cyan'
+      }
+    )
+  )
+}

--- a/test/integration/cmds/login.test.js
+++ b/test/integration/cmds/login.test.js
@@ -11,9 +11,8 @@ test('should be already logged in', done => {
   app()
     .run('login')
     .code(0)
-    .stdout(/Looks like you already stored a management token on your system\./)
+    .stdout(/You're already logged in!/)
     .stdout(/Your management token:/)
-    .stdout(/Maybe you want to contentful logout\?/)
     .end(done)
 })
 
@@ -23,7 +22,6 @@ test('should login with management-token flag', done => {
       `login --management-token ${process.env.CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN}`
     )
     .code(0)
-    .stdout(/Great! Your CMA token is now stored on your system\./)
-    .stdout(/You can always run contentful logout to remove it\./)
+    .stdout(/Great! You've successfully logged in!/)
     .end(done)
 })


### PR DESCRIPTION
## Summary

- Clean up and structure logging messages for `login` command
- Migrate `utils/async.js` to typescript

## Screenshots (if appropriate):
<img width="560" alt="Screenshot 2022-09-06 at 15 08 14" src="https://user-images.githubusercontent.com/6163988/188643453-5761b23f-daf3-4f37-9e8e-1590930044ad.png">

<img width="1051" alt="Screenshot 2022-09-06 at 00 43 52" src="https://user-images.githubusercontent.com/6163988/188518163-3a74a08b-c989-4262-b5ab-4f80f43d4b69.png">
