### PR TITLE
feat: add action parameter to login url

### DIFF
--- a/lib/cmds/login.ts
+++ b/lib/cmds/login.ts
@@ -13,7 +13,7 @@ import { Argv } from 'yargs'
 const APP_ID =
   '9f86a1d54f3d6f85c159468f5919d6e5d27716b3ed68fd01bd534e3dea2df864'
 const REDIRECT_URI = 'https://www.contentful.com/developers/cli-oauth-page/'
-const oAuthURL = `https://be.contentful.com/oauth/authorize?response_type=token&client_id=${APP_ID}&redirect_uri=${REDIRECT_URI}&scope=content_management_manage`
+const oAuthURL = `https://be.contentful.com/oauth/authorize?response_type=token&client_id=${APP_ID}&redirect_uri=${REDIRECT_URI}&scope=content_management_manage&action=cli`
 
 export const command = 'login'
 

--- a/test/unit/cmds/login.test.ts
+++ b/test/unit/cmds/login.test.ts
@@ -39,6 +39,7 @@ test('login - without error', async () => {
 
   if (['win32', 'darwin'].includes(process.platform)) {
     expect(open).toHaveBeenCalled()
+    expect(mocks.open.mock.calls[0][0].includes('action=cli')).toBeTruthy()
   }
   expect(confirmation).toHaveBeenCalledTimes(1)
   expect(prompt).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Summary

Add action parameter to login url

## Description

Add `action=cli` to login url and test that open function was called with it.

