### PR TITLE
chore: update copyright year

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -25,7 +25,7 @@ yargs
     skipValidation: true
   })
   .version(false)
-  .epilog('Copyright 2019 Contentful')
+  .epilog('Copyright 2022 Contentful')
   .fail(function (msg, err, yargs) {
     if (err) throw err
     console.error(yargs.help())


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

Small update of the copyright year.

## Motivation and Context

I noticed the copyright year wasn't changed since 2019 so I thought to do it before it gets forgotten again 😁