### PR TITLE
fix: add option to allow skipping editor interfaces

### DIFF
--- a/lib/cmds/space_cmds/export.js
+++ b/lib/cmds/space_cmds/export.js
@@ -50,6 +50,11 @@ module.exports.builder = function (yargs) {
       type: 'boolean',
       default: false
     })
+    .option('skip-editor-interfaces', {
+      describe: 'Skip editor interfaces',
+      type: 'boolean',
+      default: false
+    })
     .option('skip-roles', {
       describe: 'Skip exporting roles and permissions',
       type: 'boolean',


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

This pull requests fixes export command when supplying `skipEditorInterfaces` into the config file.

## Description

I have added an additional option to the export command to avoid `Unknown arguments` from `yargs`. Unfortunately `runContentfulExport` is not reached and the error occurs before that.

## Motivation and Context

I needed the CLI to export a content model but I got stalled through this issue, when I wanted to skip everything other than the content types. 