### PR TITLE
feat: fetch and display CDA api preview key in code examples

### DIFF
--- a/lib/cmds/init/apikey.ts
+++ b/lib/cmds/init/apikey.ts
@@ -1,0 +1,26 @@
+import { Space } from 'contentful-management'
+
+export const getPreviewApiKey = async (space: Space, environmentId: string) => {
+  let apiKey
+  const apiKeys = await space.getPreviewApiKeys()
+  if (!apiKeys.items.length) {
+    apiKey = await space.createApiKey({
+      name: space.name,
+      environments: [
+        {
+          sys: {
+            type: 'Link',
+            linkType: 'Environment',
+            id: environmentId
+          }
+        }
+      ]
+    })
+    apiKey = await space.getPreviewApiKey(apiKey.sys.id)
+    apiKey = apiKey.accessToken
+  } else {
+    apiKey = apiKeys.items[0].accessToken
+  }
+
+  return apiKey
+}

--- a/lib/cmds/init/apikey.ts
+++ b/lib/cmds/init/apikey.ts
@@ -2,9 +2,9 @@ import { Space } from 'contentful-management'
 
 export const getPreviewApiKey = async (space: Space, environmentId: string) => {
   let apiKey
-  const apiKeys = await space.getPreviewApiKeys()
-  if (!apiKeys.items.length) {
-    apiKey = await space.createApiKey({
+  const previewApiKeys = await space.getPreviewApiKeys()
+  if (!previewApiKeys.items.length) {
+    const createdApiKey = await space.createApiKey({
       name: space.name,
       environments: [
         {
@@ -16,10 +16,12 @@ export const getPreviewApiKey = async (space: Space, environmentId: string) => {
         }
       ]
     })
-    apiKey = await space.getPreviewApiKey(apiKey.sys.id)
-    apiKey = apiKey.accessToken
+    const previewApiKey = await space.getPreviewApiKey(
+      createdApiKey.preview_api_key.sys.id
+    )
+    apiKey = previewApiKey.accessToken
   } else {
-    apiKey = apiKeys.items[0].accessToken
+    apiKey = previewApiKeys.items[0].accessToken
   }
 
   return apiKey

--- a/lib/cmds/init/space.ts
+++ b/lib/cmds/init/space.ts
@@ -1,0 +1,64 @@
+import inquirer from 'inquirer'
+import { spaceCreate } from '../space_cmds/create'
+import { importSpace } from '../space_cmds/import'
+import { spaceUse } from '../space_cmds/use'
+import initialContent from './content.json'
+
+// TODO: use proper context types
+export const getSpace = async (context: any) => {
+  const { newSpace } = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'newSpace',
+      message: 'Do you want to create a new space or use an existing one?',
+      choices: [
+        {
+          name: 'Create new space',
+          value: true
+        },
+        {
+          name: 'Use existing space',
+          value: false
+        }
+      ]
+    }
+  ])
+
+  let space
+
+  if (newSpace) {
+    const { spaceName, content } = await inquirer.prompt([
+      {
+        type: 'input',
+        name: 'spaceName',
+        message: 'What should be the name for the new created space?',
+        validate: name => name !== '' || 'Space name is required'
+      },
+      {
+        type: 'confirm',
+        name: 'content',
+        message: ({ spaceName }) =>
+          `Do you want to have example content in ${spaceName}?`
+      }
+    ])
+
+    space = await spaceCreate({
+      context,
+      name: spaceName
+    })
+
+    if (content) {
+      await importSpace({
+        context: {
+          ...context,
+          activeSpaceId: space.sys.id
+        },
+        content: initialContent
+      })
+    }
+  } else {
+    space = await spaceUse({ context })
+  }
+
+  return space
+}

--- a/lib/cmds/init/success.ts
+++ b/lib/cmds/init/success.ts
@@ -32,14 +32,16 @@ export default async function success({
     `,
       { language: 'JavaScript' }
     ),
-    GraphQL: `
-  curl -g \\
-    -X POST \\
-    -H "Content-Type: application/json" \\
-    -H "Authorization: Bearer ${accessToken}" \\
-    -d  '{"query":"your GraphQL query here' \\
-    https://graphql.contentful.com/content/v1/spaces/${spaceId}/environments/${environmentId}
-    `,
+    GraphQL: highlight(
+      `
+    curl -g \\
+      -X POST \\
+      -H "Content-Type: application/json" \\
+      -H "Authorization: Bearer ${accessToken}" \\
+      -d  '{"query":"your GraphQL query here' \\
+      https://graphql.contentful.com/content/v1/spaces/${spaceId}/environments/${environmentId}
+      `
+    ),
     'REST API': `
   curl --include \\
     --request GET \\


### PR DESCRIPTION
## Summary

Previously we were displaying CMA access token in CDA requests code example. Instead we should display CDA access token. This PR does the following:

* Fetch or create CDA preview api access token
* Abstract space creation flow to it's own function for better readability 


## Todos Next PRs

- Write e2e tests for init command
- Try out https://github.com/highlightjs/highlight.js#nodejs-on-the-server instead of the old cli-highlights, fix and test code examples

## Screenshots (if appropriate):

<img width="756" alt="Screenshot 2022-09-20 at 16 54 34" src="https://user-images.githubusercontent.com/6163988/191291796-bd021b05-16fe-495e-a88c-a27aa62190c1.png">

