### PR TITLE
fix: update contentful-migration packge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "contentful-cli",
       "version": "0.0.0-determined-by-semantic-release",
       "license": "MIT",
       "dependencies": {
@@ -19,7 +20,7 @@
         "contentful-export": "^7.17.16",
         "contentful-import": "^8.3.2",
         "contentful-management": "^10.0.0",
-        "contentful-migration": "^4.8.0",
+        "contentful-migration": "^4.12.2",
         "emojic": "^1.1.11",
         "execa": "^5.0.0",
         "figlet": "^1.2.0",
@@ -4240,9 +4241,9 @@
       }
     },
     "node_modules/contentful-migration": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/contentful-migration/-/contentful-migration-4.12.1.tgz",
-      "integrity": "sha512-6kQtIC8k0A4vOjX+Jj5T2Z7nCd3ovyPPQjWKMOQooJ7CXuDjnIC++vR1ti+MyDNh95D0jWbbyCDTZpIp8/Suhw==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/contentful-migration/-/contentful-migration-4.12.2.tgz",
+      "integrity": "sha512-5TPpPrF5jSnYzHbJ5ngjMmcTDsoHnov9ZKbSOGiH+7X69v2AeIyiVMNB7Ys1H8YQY9Aq8gC/WOqHKK6telwE4Q==",
       "dependencies": {
         "@hapi/hoek": "^10.0.1",
         "axios": "^0.21.0",
@@ -22288,9 +22289,9 @@
       }
     },
     "contentful-migration": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/contentful-migration/-/contentful-migration-4.12.1.tgz",
-      "integrity": "sha512-6kQtIC8k0A4vOjX+Jj5T2Z7nCd3ovyPPQjWKMOQooJ7CXuDjnIC++vR1ti+MyDNh95D0jWbbyCDTZpIp8/Suhw==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/contentful-migration/-/contentful-migration-4.12.2.tgz",
+      "integrity": "sha512-5TPpPrF5jSnYzHbJ5ngjMmcTDsoHnov9ZKbSOGiH+7X69v2AeIyiVMNB7Ys1H8YQY9Aq8gC/WOqHKK6telwE4Q==",
       "requires": {
         "@hapi/hoek": "^10.0.1",
         "axios": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "contentful-export": "^7.17.16",
     "contentful-import": "^8.3.2",
     "contentful-management": "^10.0.0",
-    "contentful-migration": "^4.8.0",
+    "contentful-migration": "^4.12.2",
     "emojic": "^1.1.11",
     "execa": "^5.0.0",
     "figlet": "^1.2.0",


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

Updating the contentful-migration dependency to the newest version (`4.12.2`)
