### PR TITLE
feat: add typescript support [SDK-2439]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
       - run: npm ci
       - run: npm test
+      - run: npm run tsc -- --noEmit
   integration:
     docker:
       - image: cimg/node:16.11

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist
 build
+output
 
 # Docker
 *.dockerfile
@@ -14,7 +15,6 @@ build
 # Visual Studio Code - https://code.visualstudio.com/
 .settings/
 .vscode/
-tsconfig.json
 jsconfig.json
 
 ### Linux ###

--- a/bin/contentful.js
+++ b/bin/contentful.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../lib/cli.js')
+require('../output/lib/cli.js')

--- a/lib/cmds/organization.ts
+++ b/lib/cmds/organization.ts
@@ -1,8 +1,10 @@
+import type { Argv } from 'yargs'
+
 module.exports.command = 'organization'
 
 module.exports.desc = 'Manage and list your organizations'
 
-module.exports.builder = function (yargs) {
+module.exports.builder = function (yargs: Argv) {
   return yargs
     .usage('')
     .commandDir('organization_cmds')

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "tar": "^6.0.1",
         "to-ast": "^1.0.0",
         "tree-kill": "^1.2.2",
+        "typescript": "^4.9.4",
         "wrap-ansi": "^7.0.0",
         "yargs": "~13.3.2"
       },
@@ -18557,10 +18558,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
-      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
-      "dev": true,
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -33148,10 +33148,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
-      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
-      "dev": true
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg=="
     },
     "uc-first-array": {
       "version": "1.1.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "contentful": "bin/contentful.js"
       },
       "devDependencies": {
+        "@types/yargs": "^17.0.20",
         "app-root-path": "^3.0.0",
         "axios": "^0.27.0",
         "concurrently": "^7.0.0",
@@ -1584,6 +1585,15 @@
         "node": ">= 10.14.2"
       }
     },
+    "node_modules/@jest/types/node_modules/@types/yargs": {
+      "version": "15.0.15",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.15.tgz",
+      "integrity": "sha512-IziEYMU9XoVj8hWg7k+UJrXALkGFjWJhn5QFEv9q4p+v40oZhSuC135M38st8XPjICL7Ey4TV64ferBGUoJhBg==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
     "node_modules/@jest/types/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2274,9 +2284,9 @@
       "dev": true
     },
     "node_modules/@types/yargs": {
-      "version": "15.0.14",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
-      "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -9560,6 +9570,15 @@
       },
       "engines": {
         "node": ">= 10.14.2"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/@types/yargs": {
+      "version": "15.0.15",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.15.tgz",
+      "integrity": "sha512-IziEYMU9XoVj8hWg7k+UJrXALkGFjWJhn5QFEv9q4p+v40oZhSuC135M38st8XPjICL7Ey4TV64ferBGUoJhBg==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
       }
     },
     "node_modules/jest-runtime/node_modules/ansi-styles": {
@@ -20398,6 +20417,15 @@
         "chalk": "^4.0.0"
       },
       "dependencies": {
+        "@types/yargs": {
+          "version": "15.0.15",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.15.tgz",
+          "integrity": "sha512-IziEYMU9XoVj8hWg7k+UJrXALkGFjWJhn5QFEv9q4p+v40oZhSuC135M38st8XPjICL7Ey4TV64ferBGUoJhBg==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -20988,9 +21016,9 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "15.0.14",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
-      "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+      "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -26458,6 +26486,15 @@
         "yargs": "^15.4.1"
       },
       "dependencies": {
+        "@types/yargs": {
+          "version": "15.0.15",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.15.tgz",
+          "integrity": "sha512-IziEYMU9XoVj8hWg7k+UJrXALkGFjWJhn5QFEv9q4p+v40oZhSuC135M38st8XPjICL7Ey4TV64ferBGUoJhBg==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
   "author": "Contentful <opensource@contentful.com>",
   "license": "MIT",
   "scripts": {
+    "tsc": "tsc",
     "audit": "resolve-audit",
-    "build:standalone": "pkg --targets node16-macos-x64,node16-linux-x64,node16-win-x64 --out-dir build .",
+    "build:standalone": "npm run tsc && pkg --targets node16-macos-x64,node16-linux-x64,node16-win-x64 --out-dir build .",
     "build:package": "npm run build:standalone && script/package",
     "lint": "eslint bin lib test",
     "test": "npm run test:coverage",
@@ -99,6 +100,7 @@
     "tar": "^6.0.1",
     "to-ast": "^1.0.0",
     "tree-kill": "^1.2.2",
+    "typescript": "^4.9.4",
     "wrap-ansi": "^7.0.0",
     "yargs": "~13.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:html-coverage": "nyc --reporter=html npm run test:unit",
     "test:unit": "jest --runInBand test/unit/** --verbose",
     "test:unit:watch": "jest test/unit/** --verbose --watch",
-    "pretest:integration": "node test/integration/scripts/pre-test.js",
+    "pretest:integration": "node test/integration/scripts/pre-test.js && npm run build:standalone",
     "pretest:integration:ci": "npm run pretest:integration",
     "pretest:integration:update": "npm run pretest:integration",
     "posttest:integration": "node test/integration/scripts/post-test.js",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "semantic-release": "semantic-release"
   },
   "devDependencies": {
+    "@types/yargs": "^17.0.20",
     "app-root-path": "^3.0.0",
     "axios": "^0.27.0",
     "concurrently": "^7.0.0",
@@ -135,7 +136,7 @@
   "pkg": {
     "scripts": [
       "./node_modules/blessed/lib/widgets/*.js",
-      "./lib/**/*.js"
+      "./output/**/*.js"
     ],
     "assets": [
       "./node_modules/figlet/fonts/Standard.flf"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "target": "es2018",
+    "lib": ["es2018"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "outDir": "output"
+  },
+  "include": ["lib"],
+  "exclude": ["node_modules", "bin", "docs", "recordings"]
+}


### PR DESCRIPTION
## Summary
This PR introduces support for Typescript to the project. It introduces one new dependency - tsc.

The new build flow consists now of transpiling the whole project to `output` directory and later it's build to a single executable with pkg as before