### PR TITLE
Feat: Add `merge` command and initial `export` subcommand 

### DIFF
--- a/lib/cmds/merge.ts
+++ b/lib/cmds/merge.ts
@@ -1,0 +1,12 @@
+import type { Argv } from 'yargs'
+
+module.exports.command = 'merge'
+
+module.exports.desc = 'A CLI version of the merge app'
+
+module.exports.builder = function (yargs: Argv) {
+  return yargs
+    .usage('')
+    .commandDir('merge_cmds')
+    .demandCommand(4, 'Please specify a sub command.')
+}

--- a/lib/cmds/merge_cmds/export.ts
+++ b/lib/cmds/merge_cmds/export.ts
@@ -1,0 +1,49 @@
+import type { Argv } from 'yargs'
+
+module.exports.command = 'export'
+
+module.exports.desc = 'Export diff between two environments as a migration'
+
+module.exports.builder = (yargs: Argv) => {
+  return yargs
+    .usage('Usage: contentful merge export')
+    .option('source-environment-id', {
+      alias: 's',
+      type: 'string',
+      demand: true,
+      describe: 'Source environment id'
+    })
+    .option('target-environment-id', {
+      alias: 't',
+      type: 'string',
+      demand: true,
+      describe: 'Target environment id'
+    })
+    .option('output-file', {
+      alias: 'o',
+      type: 'string',
+      describe:
+        'Output file. It defaults to ./migrations/<timestamp>-<space-id>-<source-environment-id>-<target-environment-id>.js'
+    })
+}
+
+interface Context {
+  managementToken?: string
+}
+
+interface ExportMigrationOptions {
+  context: Context
+  sourceEnvironmentId: string
+  targetEnvironmentId: string
+  outputFile?: string
+}
+
+const exportEnvironmentMigration = ({
+  context,
+  sourceEnvironmentId,
+  targetEnvironmentId
+}: ExportMigrationOptions) => {
+  console.log('export', context, sourceEnvironmentId, targetEnvironmentId)
+}
+
+module.exports.handler = exportEnvironmentMigration

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "scripts": {
     "audit": "resolve-audit",
-    "build:standalone": "pkg --targets node12-macos-x64,node12-linux-x64,node12-win-x64 --out-dir build .",
+    "build:standalone": "npm run tsc && pkg --targets node12-macos-x64,node12-linux-x64,node12-win-x64 --out-dir build .",
     "build:package": "npm run build:standalone && script/package",
     "lint": "eslint bin lib test",
     "test": "npm run test:coverage",

--- a/test/integration/cmds/__snapshots__/main.test.js.snap
+++ b/test/integration/cmds/__snapshots__/main.test.js.snap
@@ -10,6 +10,7 @@ Commands:
   init          Get started with Contentful
   login         Login to Contentful
   logout        Logout from Contentful
+  merge         A CLI version of the merge app
   organization  Manage and list your organizations
   space         Manage and list your spaces
 
@@ -30,6 +31,7 @@ Commands:
   init          Get started with Contentful
   login         Login to Contentful
   logout        Logout from Contentful
+  merge         A CLI version of the merge app
   organization  Manage and list your organizations
   space         Manage and list your spaces
 
@@ -51,6 +53,7 @@ Commands:
   init          Get started with Contentful
   login         Login to Contentful
   logout        Logout from Contentful
+  merge         A CLI version of the merge app
   organization  Manage and list your organizations
   space         Manage and list your spaces
 
@@ -71,6 +74,7 @@ Commands:
   init          Get started with Contentful
   login         Login to Contentful
   logout        Logout from Contentful
+  merge         A CLI version of the merge app
   organization  Manage and list your organizations
   space         Manage and list your spaces
 


### PR DESCRIPTION
## Summary

Adds the scaffold to add commands to the `merge` subcommand and the initial `merge export` command with source and target envs

