### PR TITLE
Chore: merge beta keeping old name []

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,4 +116,5 @@ workflows:
           filters:
             branches:
               only:
+                - master
                 - beta

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Make sure you have [Node LTS](https://nodejs.org/en/) installed
 Then using [npm](https://npmjs.org) or [yarn](https://yarnpkg.com):
 
 ```sh
-npm install -g contenful-cli@beta
+npm install -g contenful-cli
 # Or
-yarn global add contenful-cli@beta
+yarn global add contenful-cli
 ```
 
 Please note that for the non standalone versions you need Node LTS to use the CLI.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > [Contentful's](https://www.contentful.com) command line interface tool. Use Contentful features straight from your CLI.
 
-[![npm](https://img.shields.io/npm/v/contentful-cli.svg)](https://www.npmjs.com/package/@contentful/cli)
+[![npm](https://img.shields.io/npm/v/contentful-cli.svg)](https://www.npmjs.com/package/contenful-cli)
 [![Contentful](https://circleci.com/gh/contentful/contentful-cli.svg?style=shield)](https://circleci.com/gh/contentful/contentful-cli)
 
 [Contentful](https://www.contentful.com) provides a content infrastructure for digital teams to power content in websites, apps, and devices. Unlike a CMS, Contentful was built to integrate with the modern software stack. It offers a central hub for structured content, powerful management and delivery APIs, and a customizable web app that enable developers and content creators to ship digital products faster.
@@ -27,9 +27,9 @@ Make sure you have [Node LTS](https://nodejs.org/en/) installed
 Then using [npm](https://npmjs.org) or [yarn](https://yarnpkg.com):
 
 ```sh
-npm install -g @contentful/cli@beta
+npm install -g contenful-cli@beta
 # Or
-yarn global add @contentful/cli@beta
+yarn global add contenful-cli@beta
 ```
 
 Please note that for the non standalone versions you need Node LTS to use the CLI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@contentful/cli",
+  "name": "contentful-cli",
   "version": "0.0.0-determined-by-semantic-release",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@contentful/cli",
+      "name": "contentful-cli",
       "version": "0.0.0-determined-by-semantic-release",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@contentful/cli",
+  "name": "contentful-cli",
   "version": "0.0.0-determined-by-semantic-release",
   "description": "Contentful CLI tool",
   "main": "dist/contentful.js",


### PR DESCRIPTION
## Summary
Due to pending work needing to be done this PR modifies the name back to `contentful-cli` so we can release a new major with all the new changes that live in beta and weren't released.
This commit [contentful/contentful-cli@`8904c1a` (#1819)](https://github.com/contentful/contentful-cli/pull/1819/commits/8904c1a14ddf334ae9c8d9e522e98eb4dd61d066) should force a new relase by semantic-release

## Description

Branches out of beta only adding a new commit to change the package name back

