### PR TITLE
feat: add app installation before export [SDK-2441]

### DIFF
--- a/.jest/setup.js
+++ b/.jest/setup.js
@@ -1,7 +1,8 @@
 import { cleanUpTestSpaces } from '@contentful/integration-test-utils'
 import { initConfig } from '../test/contentful-config'
 
-beforeAll(() => {
+beforeAll(async () => {
+  await cleanUpTestSpaces({ threshold: 60 * 1000 })
   return initConfig()
 })
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  transform: {
+    '\\.[jt]sx?$': 'babel-jest'
+  },
   testEnvironment: 'node',
   testEnvironmentOptions: {
     url: 'http://localhost/'

--- a/lib/cmds/merge.ts
+++ b/lib/cmds/merge.ts
@@ -2,7 +2,7 @@ import type { Argv } from 'yargs'
 
 module.exports.command = 'merge'
 
-module.exports.desc = 'A CLI version of the merge app'
+module.exports.desc = 'A CLI version of the Merge app'
 
 module.exports.builder = function (yargs: Argv) {
   return yargs

--- a/lib/cmds/merge_cmds/export.ts
+++ b/lib/cmds/merge_cmds/export.ts
@@ -1,4 +1,12 @@
 import type { Argv } from 'yargs'
+import { handleAsyncError as handle } from '../../utils/async'
+import { success, warning } from '../../utils/log'
+import { confirmation } from '../../utils/actions'
+import { installApp, isAppInstalled } from '../../utils/app-installation'
+import { createManagementClient } from '../../utils/contentful-clients'
+import { type ClientAPI } from 'contentful-management'
+
+const MERGE_APP_ID = 'cQeaauOu1yUCYVhQ00atE'
 
 module.exports.command = 'export'
 
@@ -19,6 +27,10 @@ module.exports.builder = (yargs: Argv) => {
       demand: true,
       describe: 'Target environment id'
     })
+    .option('yes', {
+      alias: 'y',
+      describe: 'Confirm merge app installation without prompt'
+    })
     .option('output-file', {
       alias: 'o',
       type: 'string',
@@ -28,6 +40,7 @@ module.exports.builder = (yargs: Argv) => {
 }
 
 interface Context {
+  activeSpaceId: string
   managementToken?: string
 }
 
@@ -35,15 +48,133 @@ interface ExportMigrationOptions {
   context: Context
   sourceEnvironmentId: string
   targetEnvironmentId: string
+  yes?: boolean
   outputFile?: string
 }
 
-const exportEnvironmentMigration = ({
-  context,
-  sourceEnvironmentId,
-  targetEnvironmentId
-}: ExportMigrationOptions) => {
-  console.log('export', context, sourceEnvironmentId, targetEnvironmentId)
+const promptAppInstallationInEnvironment = async (
+  client: ClientAPI,
+  spaceId: string,
+  environmentId: string,
+  appId: string
+) => {
+  warning(
+    `The Merge app is not installed in the environment with id: ${environmentId}`
+  )
+
+  const userConfirmation = await confirmation(
+    `Do you want to install the Merge app in the environment with id: ${environmentId}`
+  )
+
+  if (userConfirmation) {
+    return false
+  }
+
+  await installApp(client, {
+    spaceId,
+    environmentId: environmentId,
+    appId
+  })
+
+  return true
 }
 
-module.exports.handler = exportEnvironmentMigration
+export const checkAndInstallAppInEnvironments = async (
+  client: ClientAPI,
+  spaceId: string,
+  environmentIds: [string, string],
+  appId: string,
+  continueWithoutPrompt: boolean
+) => {
+  const appInstallations = {
+    source: await isAppInstalled(client, {
+      spaceId: spaceId,
+      environmentId: environmentIds[0],
+      appId: MERGE_APP_ID
+    }),
+    target: await isAppInstalled(client, {
+      spaceId: spaceId,
+      environmentId: environmentIds[1],
+      appId: MERGE_APP_ID
+    })
+  }
+
+  if (appInstallations.source && appInstallations.target) {
+    return true
+  }
+
+  // User has passed the --yes flag
+  if (continueWithoutPrompt) {
+    // Install the app in both environments. If it's already installed it will just continue.
+    await installApp(client, {
+      spaceId,
+      environmentId: environmentIds,
+      appId
+    })
+  } else {
+    if (!appInstallations.source && !appInstallations.target) {
+      warning(
+        `The Merge app is not installed in any of the environments. Environment ids: ${environmentIds[0]}, ${environmentIds[1]}`
+      )
+      const userConfirmation = await confirmation(
+        `Do you want to install the Merge app in both environments?`
+      )
+
+      if (!userConfirmation) {
+        return false
+      }
+
+      await installApp(client, {
+        spaceId,
+        environmentId: environmentIds,
+        appId
+      })
+    } else {
+      for (const env of environmentIds) {
+        const prompt = await promptAppInstallationInEnvironment(
+          client,
+          spaceId,
+          env,
+          MERGE_APP_ID
+        )
+
+        if (!prompt) {
+          return false
+        }
+      }
+    }
+  }
+  return true
+}
+
+const exportEnvironmentMigration = async ({
+  context,
+  sourceEnvironmentId,
+  targetEnvironmentId,
+  yes = false
+}: ExportMigrationOptions) => {
+  const { managementToken, activeSpaceId } = context
+  const client = await createManagementClient({
+    accessToken: managementToken
+  })
+
+  if (sourceEnvironmentId === targetEnvironmentId) {
+    throw new Error('Source and target environments cannot be the same.')
+  }
+
+  const appInstalled = await checkAndInstallAppInEnvironments(
+    client,
+    activeSpaceId,
+    [sourceEnvironmentId, targetEnvironmentId],
+    MERGE_APP_ID,
+    yes
+  )
+
+  if (!appInstalled) {
+    throw new Error('Merge app could not be installed in the environments.')
+  }
+
+  success(`Exporting environment migration...`)
+}
+
+module.exports.handler = handle(exportEnvironmentMigration)

--- a/lib/cmds/merge_cmds/export.ts
+++ b/lib/cmds/merge_cmds/export.ts
@@ -1,7 +1,7 @@
 import type { Argv } from 'yargs'
 import { handleAsyncError as handle } from '../../utils/async'
 import { success } from '../../utils/log'
-import { createManagementClient } from '../../utils/contentful-clients'
+import { createPlainClient } from '../../utils/contentful-clients'
 import { checkAndInstallAppInEnvironments } from '../../utils/app-installation'
 
 const MERGE_APP_ID = 'cQeaauOu1yUCYVhQ00atE'
@@ -27,7 +27,7 @@ module.exports.builder = (yargs: Argv) => {
     })
     .option('yes', {
       alias: 'y',
-      describe: 'Confirm merge app installation without prompt'
+      describe: 'Confirm Merge app installation without prompt'
     })
     .option('output-file', {
       alias: 'o',
@@ -57,7 +57,7 @@ const exportEnvironmentMigration = async ({
   yes = false
 }: ExportMigrationOptions) => {
   const { managementToken, activeSpaceId } = context
-  const client = await createManagementClient({
+  const client = await createPlainClient({
     accessToken: managementToken
   })
 

--- a/lib/utils/app-installation.ts
+++ b/lib/utils/app-installation.ts
@@ -1,4 +1,6 @@
 import { ClientAPI } from 'contentful-management'
+import { confirmation } from './actions'
+import { warning } from './log'
 
 /**
  * Checks if a specified app is installed in an environment
@@ -57,4 +59,99 @@ export async function installApp(
       }
     })
   }
+}
+
+const promptAppInstallationInEnvironment = async (
+  client: ClientAPI,
+  spaceId: string,
+  environmentId: string,
+  appId: string
+) => {
+  warning(
+    `The Merge app is not installed in the environment with id: ${environmentId}`
+  )
+
+  const userConfirmation = await confirmation(
+    `Do you want to install the Merge app in the environment with id: ${environmentId}`
+  )
+
+  if (userConfirmation) {
+    return false
+  }
+
+  await installApp(client, {
+    spaceId,
+    environmentId: environmentId,
+    appId
+  })
+
+  return true
+}
+
+export const checkAndInstallAppInEnvironments = async (
+  client: ClientAPI,
+  spaceId: string,
+  environmentIds: [string, string],
+  appId: string,
+  continueWithoutPrompt: boolean
+) => {
+  const appInstallations = {
+    source: await isAppInstalled(client, {
+      spaceId: spaceId,
+      environmentId: environmentIds[0],
+      appId
+    }),
+    target: await isAppInstalled(client, {
+      spaceId: spaceId,
+      environmentId: environmentIds[1],
+      appId
+    })
+  }
+
+  if (appInstallations.source && appInstallations.target) {
+    return true
+  }
+
+  // User has passed the --yes flag
+  if (continueWithoutPrompt) {
+    // Install the app in both environments. If it's already installed it will just continue.
+    await installApp(client, {
+      spaceId,
+      environmentId: environmentIds,
+      appId
+    })
+  } else {
+    if (!appInstallations.source && !appInstallations.target) {
+      warning(
+        `The Merge app is not installed in any of the environments. Environment ids: ${environmentIds[0]}, ${environmentIds[1]}`
+      )
+      const userConfirmation = await confirmation(
+        `Do you want to install the Merge app in both environments?`
+      )
+
+      if (!userConfirmation) {
+        return false
+      }
+
+      await installApp(client, {
+        spaceId,
+        environmentId: environmentIds,
+        appId
+      })
+    } else {
+      for (const env of environmentIds) {
+        const prompt = await promptAppInstallationInEnvironment(
+          client,
+          spaceId,
+          env,
+          appId
+        )
+
+        if (!prompt) {
+          return false
+        }
+      }
+    }
+  }
+  return true
 }

--- a/lib/utils/app-installation.ts
+++ b/lib/utils/app-installation.ts
@@ -3,7 +3,7 @@ import { ClientAPI } from 'contentful-management'
 /**
  * Checks if a specified app is installed in an environment
  */
-async function isAppInstalled(
+export async function isAppInstalled(
   client: ClientAPI,
   {
     spaceId,
@@ -32,4 +32,29 @@ async function isAppInstalled(
   }
 }
 
-module.exports.isAppInstalled = isAppInstalled
+export async function installApp(
+  client: ClientAPI,
+  {
+    spaceId,
+    environmentId,
+    appId
+  }: {
+    spaceId: string
+    environmentId: string | string[]
+    appId: string
+  }
+): Promise<void> {
+  const environments = Array.isArray(environmentId)
+    ? environmentId
+    : [environmentId]
+
+  for (const environmentId of environments) {
+    await client.rawRequest({
+      method: 'PUT',
+      url: `/spaces/${spaceId}/environments/${environmentId}/app_installations/${appId}`,
+      data: {
+        parameters: {}
+      }
+    })
+  }
+}

--- a/lib/utils/contentful-clients.js
+++ b/lib/utils/contentful-clients.js
@@ -20,4 +20,24 @@ async function createManagementClient(params) {
   return createClient({ ...params, ...proxyConfig, host, insecure })
 }
 
-module.exports.createManagementClient = createManagementClient
+async function createPlainClient(params, defaults = {}) {
+  params.application = `contentful.cli/${version}`
+
+  const context = await getContext()
+  const { rawProxy, proxy, host, insecure } = context
+
+  const proxyConfig = {}
+  if (!rawProxy) {
+    const { httpsAgent } = agentFromProxy(proxy)
+    proxyConfig.httpsAgent = httpsAgent
+  } else {
+    proxyConfig.proxy = proxy
+  }
+
+  return createClient(
+    { ...params, ...proxyConfig, host, insecure },
+    { type: 'plain', defaults }
+  )
+}
+
+module.exports = { createManagementClient, createPlainClient }

--- a/test/integration/cmds/__snapshots__/main.test.js.snap
+++ b/test/integration/cmds/__snapshots__/main.test.js.snap
@@ -10,7 +10,7 @@ Commands:
   init          Get started with Contentful
   login         Login to Contentful
   logout        Logout from Contentful
-  merge         A CLI version of the merge app
+  merge         A CLI version of the Merge app
   organization  Manage and list your organizations
   space         Manage and list your spaces
 
@@ -31,7 +31,7 @@ Commands:
   init          Get started with Contentful
   login         Login to Contentful
   logout        Logout from Contentful
-  merge         A CLI version of the merge app
+  merge         A CLI version of the Merge app
   organization  Manage and list your organizations
   space         Manage and list your spaces
 
@@ -53,7 +53,7 @@ Commands:
   init          Get started with Contentful
   login         Login to Contentful
   logout        Logout from Contentful
-  merge         A CLI version of the merge app
+  merge         A CLI version of the Merge app
   organization  Manage and list your organizations
   space         Manage and list your spaces
 
@@ -74,7 +74,7 @@ Commands:
   init          Get started with Contentful
   login         Login to Contentful
   logout        Logout from Contentful
-  merge         A CLI version of the merge app
+  merge         A CLI version of the Merge app
   organization  Manage and list your organizations
   space         Manage and list your spaces
 

--- a/test/integration/cmds/merge/__snapshots__/export.test.ts.snap
+++ b/test/integration/cmds/merge/__snapshots__/export.test.ts.snap
@@ -7,7 +7,7 @@ Options:
   -h, --help                   Show help                               [boolean]
   --source-environment-id, -s  Source environment id         [string] [required]
   --target-environment-id, -t  Target environment id         [string] [required]
-  --yes, -y                    Confirm merge app installation without prompt
+  --yes, -y                    Confirm Merge app installation without prompt
   --output-file, -o            Output file. It defaults to
                                ./migrations/<timestamp>-<space-id>-<source-envir
                                onment-id>-<target-environment-id>.js    [string]"

--- a/test/integration/cmds/merge/__snapshots__/export.test.ts.snap
+++ b/test/integration/cmds/merge/__snapshots__/export.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`merge export snapshots show the help properly: help data is incorrect 1`] = `
+exports[`merge export snapshots shows the help properly: help data is incorrect 1`] = `
 "Usage: contentful merge export
 
 Options:

--- a/test/integration/cmds/merge/__snapshots__/export.test.ts.snap
+++ b/test/integration/cmds/merge/__snapshots__/export.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`merge export snapshots show the help properly: help data is incorrect 1`] = `
 "Usage: contentful merge export
+
 Options:
   -h, --help                   Show help                               [boolean]
   --source-environment-id, -s  Source environment id         [string] [required]

--- a/test/integration/cmds/merge/__snapshots__/export.test.ts.snap
+++ b/test/integration/cmds/merge/__snapshots__/export.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`merge export snapshots show the help properly: help data is incorrect 1`] = `
+"Usage: contentful merge export
+Options:
+  -h, --help                   Show help                               [boolean]
+  --source-environment-id, -s  Source environment id         [string] [required]
+  --target-environment-id, -t  Target environment id         [string] [required]
+  --yes, -y                    Confirm merge app installation without prompt
+  --output-file, -o            Output file. It defaults to
+                               ./migrations/<timestamp>-<space-id>-<source-envir
+                               onment-id>-<target-environment-id>.js    [string]"
+`;

--- a/test/integration/cmds/merge/export.test.ts
+++ b/test/integration/cmds/merge/export.test.ts
@@ -13,7 +13,7 @@ type Result = {
 }
 
 describe('merge export snapshots', () => {
-  it('show the help properly', done => {
+  it('shows the help properly', done => {
     app()
       .run('merge export --help')
       .code(0)

--- a/test/integration/cmds/merge/export.test.ts
+++ b/test/integration/cmds/merge/export.test.ts
@@ -1,0 +1,85 @@
+import nixt from 'nixt'
+import { join } from 'path'
+
+const bin = join(__dirname, './../../../../', 'bin')
+
+const app = () => {
+  return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
+}
+
+type Result = {
+  stderr: string
+  stdout: string
+}
+
+describe('merge export snapshots', () => {
+  it('show the help properly', done => {
+    app()
+      .run('merge export --help')
+      .code(0)
+      .expect(({ stdout }: Result) => {
+        const resultText = stdout.trim()
+        expect(resultText).toMatchSnapshot('help data is incorrect')
+      })
+      .end(done)
+  })
+})
+
+describe('merge export command args validation', () => {
+  it('should exit 1 when no args', done => {
+    app()
+      .run('merge export')
+      .code(1)
+      .expect(({ stderr }: Result) => {
+        const resultText = stderr.trim()
+        expect(resultText).toContain('Usage: contentful merge export')
+      })
+      .end(done)
+  })
+
+  it('should exit 1 when no source environment', done => {
+    app()
+      .run('merge export --t target')
+      .code(1)
+      .expect(({ stderr }: Result) => {
+        const resultText = stderr.trim()
+        expect(resultText).toContain('Usage: contentful merge export')
+      })
+      .end(done)
+  })
+
+  it('should exit 1 when no target environment', done => {
+    app()
+      .run('merge export --s source')
+      .code(1)
+      .expect(({ stderr }: Result) => {
+        const resultText = stderr.trim()
+        expect(resultText).toContain('Usage: contentful merge export')
+      })
+      .end(done)
+  })
+
+  it('should exit 1 when no space id passed or in context', done => {
+    app()
+      .run('merge export --s source --t source')
+      .code(1)
+      .expect(({ stderr }: Result) => {
+        const resultText = stderr.trim()
+        expect(resultText).toContain('Error: You need to provide a space id')
+      })
+      .end(done)
+  })
+
+  it('should exit 1 when source and target are the same', done => {
+    app()
+      .run('merge export --s source --t source --space-id space')
+      .code(1)
+      .expect(({ stderr }: Result) => {
+        const resultText = stderr.trim()
+        expect(resultText).toContain(
+          'Source and target environments cannot be the same.'
+        )
+      })
+      .end(done)
+  })
+})

--- a/test/integration/util.js
+++ b/test/integration/util.js
@@ -2,7 +2,11 @@ import appRoot from 'app-root-path'
 import { resolve } from 'path'
 import { homedir } from 'os'
 import { createManagementClient } from '../../lib/utils/contentful-clients'
-import { createTestSpace, initClient } from '@contentful/integration-test-utils'
+import {
+  createTestEnvironment,
+  createTestSpace,
+  initClient
+} from '@contentful/integration-test-utils'
 
 module.exports.expectedDir = `${appRoot}/test/integration/expected`
 module.exports.tmpDir = `${appRoot}/test/integration/expected/tmp`
@@ -17,7 +21,7 @@ export function extractSpaceId(text) {
   return found[1]
 }
 
-const client = initClient()
+export const client = initClient()
 
 export async function createSimpleSpace(testSuiteName = 'CLI Test Space') {
   return createTestSpace({
@@ -27,6 +31,17 @@ export async function createSimpleSpace(testSuiteName = 'CLI Test Space') {
     language: 'JS',
     testSuiteName
   })
+}
+
+export async function createSimpleEnvironment(spaceId, environmentName) {
+  const space = await client.getSpace(spaceId)
+
+  return createTestEnvironment(space, environmentName)
+}
+
+export async function deleteSpace(spaceId) {
+  const space = await client.getSpace(spaceId)
+  await space.delete()
 }
 
 async function addNewCT(spaceId, name, fields) {

--- a/test/unit/cmds/merge_cmds/export.test.ts
+++ b/test/unit/cmds/merge_cmds/export.test.ts
@@ -6,7 +6,7 @@ const mockedClient = {
   rawRequest: jest.fn()
 } as unknown as ClientAPI
 
-describe.only('merge export command', () => {
+describe('merge export command', () => {
   const isAppInstalled = jest.spyOn(appInstallUtils, 'isAppInstalled')
   const installApp = jest.spyOn(appInstallUtils, 'installApp')
 

--- a/test/unit/cmds/merge_cmds/export.test.ts
+++ b/test/unit/cmds/merge_cmds/export.test.ts
@@ -1,10 +1,15 @@
-import { ClientAPI } from 'contentful-management'
-import { checkAndInstallAppInEnvironments } from '../../../../lib/cmds/merge_cmds/export'
+import { PlainClientAPI } from 'contentful-management'
+
 import * as appInstallUtils from '../../../../lib/utils/app-installation'
 
 const mockedClient = {
-  rawRequest: jest.fn()
-} as unknown as ClientAPI
+  appInstallation: {
+    get: jest.fn()
+  },
+  raw: {
+    put: jest.fn()
+  }
+} as unknown as PlainClientAPI
 
 describe('merge export command', () => {
   const isAppInstalled = jest.spyOn(appInstallUtils, 'isAppInstalled')
@@ -18,13 +23,14 @@ describe('merge export command', () => {
   it('stops early if both env have the app installed', async () => {
     isAppInstalled.mockResolvedValue(true)
 
-    const appInstalledInBothEnvs = await checkAndInstallAppInEnvironments(
-      mockedClient,
-      'space',
-      ['source', 'target'],
-      'app-id',
-      false
-    )
+    const appInstalledInBothEnvs =
+      await appInstallUtils.checkAndInstallAppInEnvironments(
+        mockedClient,
+        'space',
+        ['source', 'target'],
+        'app-id',
+        false
+      )
 
     expect(appInstalledInBothEnvs).toBe(true)
     expect(isAppInstalled).toHaveBeenCalledTimes(2)
@@ -35,13 +41,14 @@ describe('merge export command', () => {
 
     const installApp = jest.spyOn(appInstallUtils, 'installApp')
 
-    const appInstalledInBothEnvs = await checkAndInstallAppInEnvironments(
-      mockedClient,
-      'space',
-      ['source', 'target'],
-      'app-id',
-      true
-    )
+    const appInstalledInBothEnvs =
+      await appInstallUtils.checkAndInstallAppInEnvironments(
+        mockedClient,
+        'space',
+        ['source', 'target'],
+        'app-id',
+        true
+      )
 
     expect(appInstalledInBothEnvs).toBe(true)
     expect(isAppInstalled).toHaveBeenCalledTimes(2)
@@ -51,13 +58,14 @@ describe('merge export command', () => {
   it('installs the app in the other env if only one has it installed', async () => {
     isAppInstalled.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
 
-    const appInstalledInBothEnvs = await checkAndInstallAppInEnvironments(
-      mockedClient,
-      'space',
-      ['source', 'target'],
-      'app-id',
-      true
-    )
+    const appInstalledInBothEnvs =
+      await appInstallUtils.checkAndInstallAppInEnvironments(
+        mockedClient,
+        'space',
+        ['source', 'target'],
+        'app-id',
+        true
+      )
 
     expect(appInstalledInBothEnvs).toBe(true)
     expect(isAppInstalled).toHaveBeenCalledTimes(2)

--- a/test/unit/cmds/merge_cmds/export.test.ts
+++ b/test/unit/cmds/merge_cmds/export.test.ts
@@ -12,17 +12,11 @@ const mockedClient = {
 } as unknown as PlainClientAPI
 
 describe('merge export command', () => {
-  const isAppInstalled = jest.spyOn(appInstallUtils, 'isAppInstalled')
-  const installApp = jest.spyOn(appInstallUtils, 'installApp')
-
   beforeEach(() => {
-    isAppInstalled.mockClear()
-    installApp.mockClear()
+    jest.clearAllMocks()
   })
 
   it('stops early if both env have the app installed', async () => {
-    isAppInstalled.mockResolvedValue(true)
-
     const appInstalledInBothEnvs =
       await appInstallUtils.checkAndInstallAppInEnvironments(
         mockedClient,
@@ -33,13 +27,13 @@ describe('merge export command', () => {
       )
 
     expect(appInstalledInBothEnvs).toBe(true)
-    expect(isAppInstalled).toHaveBeenCalledTimes(2)
+    expect(mockedClient.appInstallation.get).toHaveBeenCalledTimes(2)
   })
 
   it('installs app to both envs if none of them have it installed', async () => {
-    isAppInstalled.mockResolvedValue(false)
-
-    const installApp = jest.spyOn(appInstallUtils, 'installApp')
+    mockedClient.appInstallation.get = jest.fn().mockImplementationOnce(() => {
+      throw { name: 'NotFound' }
+    })
 
     const appInstalledInBothEnvs =
       await appInstallUtils.checkAndInstallAppInEnvironments(
@@ -51,13 +45,11 @@ describe('merge export command', () => {
       )
 
     expect(appInstalledInBothEnvs).toBe(true)
-    expect(isAppInstalled).toHaveBeenCalledTimes(2)
-    expect(installApp).toHaveBeenCalledTimes(1)
+    expect(mockedClient.appInstallation.get).toHaveBeenCalledTimes(2)
+    expect(mockedClient.raw.put).toHaveBeenCalledTimes(2)
   })
 
   it('installs the app in the other env if only one has it installed', async () => {
-    isAppInstalled.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
-
     const appInstalledInBothEnvs =
       await appInstallUtils.checkAndInstallAppInEnvironments(
         mockedClient,
@@ -68,6 +60,6 @@ describe('merge export command', () => {
       )
 
     expect(appInstalledInBothEnvs).toBe(true)
-    expect(isAppInstalled).toHaveBeenCalledTimes(2)
+    expect(mockedClient.appInstallation.get).toHaveBeenCalledTimes(2)
   })
 })

--- a/test/unit/cmds/merge_cmds/export.test.ts
+++ b/test/unit/cmds/merge_cmds/export.test.ts
@@ -1,0 +1,65 @@
+import { ClientAPI } from 'contentful-management'
+import { checkAndInstallAppInEnvironments } from '../../../../lib/cmds/merge_cmds/export'
+import * as appInstallUtils from '../../../../lib/utils/app-installation'
+
+const mockedClient = {
+  rawRequest: jest.fn()
+} as unknown as ClientAPI
+
+describe.only('merge export command', () => {
+  const isAppInstalled = jest.spyOn(appInstallUtils, 'isAppInstalled')
+  const installApp = jest.spyOn(appInstallUtils, 'installApp')
+
+  beforeEach(() => {
+    isAppInstalled.mockClear()
+    installApp.mockClear()
+  })
+
+  it('stops early if both env have the app installed', async () => {
+    isAppInstalled.mockResolvedValue(true)
+
+    const ret = await checkAndInstallAppInEnvironments(
+      mockedClient,
+      'space',
+      ['source', 'target'],
+      'app-id',
+      false
+    )
+
+    expect(ret).toBe(true)
+    expect(isAppInstalled).toHaveBeenCalledTimes(2)
+  })
+
+  it('installs app to both apps if none of them have it installed', async () => {
+    isAppInstalled.mockResolvedValue(false)
+
+    const installApp = jest.spyOn(appInstallUtils, 'installApp')
+
+    const ret = await checkAndInstallAppInEnvironments(
+      mockedClient,
+      'space',
+      ['source', 'target'],
+      'app-id',
+      true
+    )
+
+    expect(ret).toBe(true)
+    expect(isAppInstalled).toHaveBeenCalledTimes(2)
+    expect(installApp).toHaveBeenCalledTimes(1)
+  })
+
+  it('installs the app in the other env if only one has it installed', async () => {
+    isAppInstalled.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+
+    const ret = await checkAndInstallAppInEnvironments(
+      mockedClient,
+      'space',
+      ['source', 'target'],
+      'app-id',
+      true
+    )
+
+    expect(ret).toBe(true)
+    expect(isAppInstalled).toHaveBeenCalledTimes(2)
+  })
+})

--- a/test/unit/cmds/merge_cmds/export.test.ts
+++ b/test/unit/cmds/merge_cmds/export.test.ts
@@ -18,7 +18,7 @@ describe('merge export command', () => {
   it('stops early if both env have the app installed', async () => {
     isAppInstalled.mockResolvedValue(true)
 
-    const ret = await checkAndInstallAppInEnvironments(
+    const appInstalledInBothEnvs = await checkAndInstallAppInEnvironments(
       mockedClient,
       'space',
       ['source', 'target'],
@@ -26,16 +26,16 @@ describe('merge export command', () => {
       false
     )
 
-    expect(ret).toBe(true)
+    expect(appInstalledInBothEnvs).toBe(true)
     expect(isAppInstalled).toHaveBeenCalledTimes(2)
   })
 
-  it('installs app to both apps if none of them have it installed', async () => {
+  it('installs app to both envs if none of them have it installed', async () => {
     isAppInstalled.mockResolvedValue(false)
 
     const installApp = jest.spyOn(appInstallUtils, 'installApp')
 
-    const ret = await checkAndInstallAppInEnvironments(
+    const appInstalledInBothEnvs = await checkAndInstallAppInEnvironments(
       mockedClient,
       'space',
       ['source', 'target'],
@@ -43,7 +43,7 @@ describe('merge export command', () => {
       true
     )
 
-    expect(ret).toBe(true)
+    expect(appInstalledInBothEnvs).toBe(true)
     expect(isAppInstalled).toHaveBeenCalledTimes(2)
     expect(installApp).toHaveBeenCalledTimes(1)
   })
@@ -51,7 +51,7 @@ describe('merge export command', () => {
   it('installs the app in the other env if only one has it installed', async () => {
     isAppInstalled.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
 
-    const ret = await checkAndInstallAppInEnvironments(
+    const appInstalledInBothEnvs = await checkAndInstallAppInEnvironments(
       mockedClient,
       'space',
       ['source', 'target'],
@@ -59,7 +59,7 @@ describe('merge export command', () => {
       true
     )
 
-    expect(ret).toBe(true)
+    expect(appInstalledInBothEnvs).toBe(true)
     expect(isAppInstalled).toHaveBeenCalledTimes(2)
   })
 })

--- a/test/unit/utils/app-installation.test.js
+++ b/test/unit/utils/app-installation.test.js
@@ -7,75 +7,76 @@ const spaceId = 'SPACE_ID'
 const environmentId = 'ENV_ID'
 const appId = 'APP_ID'
 
-test('uses the right call parameters', async () => {
-  const client = {
-    rawRequest: jest.fn()
+const client = {
+  appInstallation: {
+    get: jest.fn()
+  },
+  raw: {
+    put: jest.fn()
   }
-  const isInstalled = await isAppInstalled(client, {
-    spaceId,
-    environmentId,
-    appId
+}
+
+describe('app installation utils', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
   })
 
-  expect(client.rawRequest).toHaveBeenCalledTimes(1)
-  expect(client.rawRequest).toHaveBeenCalledWith({
-    method: 'GET',
-    url: `/spaces/${spaceId}/environments/${environmentId}/app_installations/${appId}`
-  })
-})
+  test('uses the right call parameters', async () => {
+    await isAppInstalled(client, {
+      spaceId,
+      environmentId,
+      appId
+    })
 
-test('properly handles a truthy check', async () => {
-  const client = {
-    rawRequest: jest.fn()
-  }
-  const isInstalled = await isAppInstalled(client, {
-    spaceId,
-    environmentId,
-    appId
+    expect(client.appInstallation.get).toHaveBeenCalledTimes(1)
+    expect(client.appInstallation.get).toHaveBeenCalledWith({
+      spaceId,
+      environmentId,
+      appDefinitionId: appId
+    })
   })
 
-  expect(isInstalled).toBeTruthy()
-})
+  test('properly handles a truthy check', async () => {
+    const isInstalled = await isAppInstalled(client, {
+      spaceId,
+      environmentId,
+      appId
+    })
 
-test('properly handles a faulty check', async () => {
-  const client = {
-    rawRequest: jest.fn(async () => {
+    expect(isInstalled).toBeTruthy()
+  })
+
+  test('properly handles a faulty check', async () => {
+    client.appInstallation.get = jest.fn().mockImplementationOnce(async () => {
       throw { name: 'NotFound' }
     })
-  }
-  const isInstalled = await isAppInstalled(client, {
-    spaceId,
-    environmentId,
-    appId
+
+    const isInstalled = await isAppInstalled(client, {
+      spaceId,
+      environmentId,
+      appId
+    })
+
+    expect(isInstalled).toBeFalsy()
   })
 
-  expect(isInstalled).toBeFalsy()
-})
+  test('can install an app in an environment', async () => {
+    await installApp(client, {
+      spaceId,
+      environmentId,
+      appId
+    })
 
-test('can install an app in an environment', async () => {
-  const client = {
-    rawRequest: jest.fn()
-  }
-
-  await installApp(client, {
-    spaceId,
-    environmentId,
-    appId
+    expect(client.raw.put).toHaveBeenCalledTimes(1)
   })
 
-  expect(client.rawRequest).toHaveBeenCalledTimes(1)
-})
+  test('can handle arrays when installing apps', async () => {
+    await installApp(client, {
+      spaceId,
+      environmentId: [environmentId, environmentId],
+      appId
+    })
 
-test('can handle arrays when installing apps', async () => {
-  const client = {
-    rawRequest: jest.fn()
-  }
-
-  await installApp(client, {
-    spaceId,
-    environmentId: [environmentId, environmentId],
-    appId
+    expect(client.raw.put).toHaveBeenCalledTimes(2)
   })
-
-  expect(client.rawRequest).toHaveBeenCalledTimes(2)
 })

--- a/test/unit/utils/app-installation.test.js
+++ b/test/unit/utils/app-installation.test.js
@@ -1,4 +1,7 @@
-const { isAppInstalled } = require('../../../lib/utils/app-installation')
+const {
+  isAppInstalled,
+  installApp
+} = require('../../../lib/utils/app-installation')
 
 const spaceId = 'SPACE_ID'
 const environmentId = 'ENV_ID'
@@ -47,4 +50,32 @@ test('properly handles a faulty check', async () => {
   })
 
   expect(isInstalled).toBeFalsy()
+})
+
+test('can install an app in an environment', async () => {
+  const client = {
+    rawRequest: jest.fn()
+  }
+
+  await installApp(client, {
+    spaceId,
+    environmentId,
+    appId
+  })
+
+  expect(client.rawRequest).toHaveBeenCalledTimes(1)
+})
+
+test('can handle arrays when installing apps', async () => {
+  const client = {
+    rawRequest: jest.fn()
+  }
+
+  await installApp(client, {
+    spaceId,
+    environmentId: [environmentId, environmentId],
+    appId
+  })
+
+  expect(client.rawRequest).toHaveBeenCalledTimes(2)
 })


### PR DESCRIPTION
This is a redo of #1815 with the new beta branch.

## Summary
For the upcoming commands we need to check if the merge app is installed in the user provided environments.

## Description

Adds the flow check if app is installed in the env and if it isn't and the users confirms it goes ahead and installs it
