### PR TITLE
chore: increase jest timeout to fix integration test pipeline

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  testTimeout: 15000,
   testEnvironment: 'node',
   testEnvironmentOptions: {
     url: 'http://localhost/'


### PR DESCRIPTION
Increase global jest timeout as we saw several integration test run failing. 