### PR TITLE
feat: standalone CLI [SDK-2554]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,30 @@ jobs:
       - run:
           command: npm run test:integration:ci
           no_output_timeout: 20m
+  linux:
+    docker:
+      - image: cimg/node:lts
+    steps:
+      - run: node --version
+      - run: npm --version
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run: npm ci
+      - run: npm run build:standalone
+      - run: npm run test:e2e
+  osx:
+    macos:
+      xcode: 12.5.1
+    steps:
+      - run: node --version
+      - run: npm --version
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run: npm ci
+      - run: npm run build:standalone
+      - run: npm run test:e2e
   release:
     docker:
       - image: cimg/node:lts
@@ -78,12 +102,16 @@ workflows:
     jobs:
       - unit
       - integration
+      - linux
+      - osx
       - audit
       - release:
           context: vault
           requires:
             - unit
             - integration
+            - linux
+            - osx
             - audit
           filters:
             branches:

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "lint-staged": "^13.0.0",
         "nixt": "^0.5.1",
         "nyc": "^15.0.0",
-        "pkg": "^5.0.0",
+        "pkg": "^5.8.1",
         "rimraf": "^3.0.2",
         "semantic-release": "^20.1.1",
         "stream-buffers": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "scripts": {
     "audit": "resolve-audit",
-    "build:standalone": "npm run tsc && pkg --targets node12-macos-x64,node12-linux-x64,node12-win-x64 --out-dir build .",
+    "build:standalone": "npm run tsc && pkg .",
     "build:package": "npm run build:standalone && script/package",
     "lint": "eslint bin lib test",
     "test": "npm run test:coverage",
@@ -66,7 +66,7 @@
     "lint-staged": "^13.0.0",
     "nixt": "^0.5.1",
     "nyc": "^15.0.0",
-    "pkg": "^5.0.0",
+    "pkg": "^5.8.1",
     "rimraf": "^3.0.2",
     "semantic-release": "^20.1.1",
     "stream-buffers": "^3.0.2",
@@ -141,8 +141,14 @@
     }
   },
   "pkg": {
+    "targets": [
+      "node18-macos-x64",
+      "node18-linux-x64",
+      "node18-win-x64"
+    ],
+    "outputPath": "build",
     "scripts": [
-      "./output/**/*.js"
+      "./dist/**/*.js"
     ],
     "assets": [
       "./node_modules/figlet/fonts/Standard.flf"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "license": "MIT",
   "scripts": {
     "audit": "resolve-audit",
+    "build:standalone": "npm run tsc && pkg --targets node12-macos-x64,node12-linux-x64,node12-win-x64 --out-dir build .",
+    "build:package": "npm run build:standalone && script/package",
     "lint": "eslint bin lib test",
     "test": "npm run test:coverage",
     "test:coverage": "nyc npm run test:unit",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,8 @@
       "./dist/**/*.js"
     ],
     "assets": [
-      "./node_modules/figlet/fonts/Standard.flf"
+      "./node_modules/figlet/fonts/Standard.flf",
+      "./node_modules/axios/dist/node/axios.cjs"
     ]
   },
   "lint-staged": {

--- a/test/e2e/__snapshots__/basics.test.js.snap
+++ b/test/e2e/__snapshots__/basics.test.js.snap
@@ -8,8 +8,10 @@ Commands:
   config        Manage and list your configs
   content-type  Manage and list your space content types           [aliases: ct]
   extension     Manage and list your extensions
+  init          Get started with Contentful
   login         Login to Contentful
   logout        Logout from Contentful
+  merge         A CLI version of the merge app
   organization  Manage and list your organizations
   space         Manage and list your spaces
 
@@ -17,7 +19,7 @@ Options:
   -h, --help     Show help                                             [boolean]
   -v, --version  Show current version                                  [boolean]
 
-Copyright 2013 Contentful"
+Copyright 2023 Contentful"
 `;
 
 exports[`should print help message on shortcut 1`] = `
@@ -28,8 +30,10 @@ Commands:
   config        Manage and list your configs
   content-type  Manage and list your space content types           [aliases: ct]
   extension     Manage and list your extensions
+  init          Get started with Contentful
   login         Login to Contentful
   logout        Logout from Contentful
+  merge         A CLI version of the merge app
   organization  Manage and list your organizations
   space         Manage and list your spaces
 
@@ -37,7 +41,7 @@ Options:
   -h, --help     Show help                                             [boolean]
   -v, --version  Show current version                                  [boolean]
 
-Copyright 2013 Contentful"
+Copyright 2023 Contentful"
 `;
 
 exports[`should print help message on wrong subcommand 1`] = `
@@ -48,8 +52,10 @@ Commands:
   config        Manage and list your configs
   content-type  Manage and list your space content types           [aliases: ct]
   extension     Manage and list your extensions
+  init          Get started with Contentful
   login         Login to Contentful
   logout        Logout from Contentful
+  merge         A CLI version of the merge app
   organization  Manage and list your organizations
   space         Manage and list your spaces
 
@@ -57,7 +63,7 @@ Options:
   -h, --help     Show help                                             [boolean]
   -v, --version  Show current version                                  [boolean]
 
-Copyright 2013 Contentful
+Copyright 2023 Contentful
 Please specify a command."
 `;
 
@@ -69,8 +75,10 @@ Commands:
   config        Manage and list your configs
   content-type  Manage and list your space content types           [aliases: ct]
   extension     Manage and list your extensions
+  init          Get started with Contentful
   login         Login to Contentful
   logout        Logout from Contentful
+  merge         A CLI version of the merge app
   organization  Manage and list your organizations
   space         Manage and list your spaces
 
@@ -78,6 +86,6 @@ Options:
   -h, --help     Show help                                             [boolean]
   -v, --version  Show current version                                  [boolean]
 
-Copyright 2013 Contentful
+Copyright 2023 Contentful
 Please specify a command."
 `;


### PR DESCRIPTION
## Summary

Bring back standalone builds upon request.

Solves [#1833](https://github.com/contentful/contentful-cli/issues/1833)

**Important:**
We have to add `axios` CJS file explicitly as asset, because `pkg`. can't handle ESM modules.
https://github.com/vercel/pkg/issues/1822

(If this still causes problems, we have to downgrade to < 1)