### PR TITLE
fix: pack standalone builds before release [NONE]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - run: git fetch --tags
       - run: npm ci
       - run: npm run tsc
-      - run: npm run build:standalone
+      - run: npm run build:package
       - run: npm run semantic-release
   audit:
     docker: &ref_0


### PR DESCRIPTION
Hopefully the very last bit of getting the standalone back on the releases. 