### PR TITLE
fix: update contentful-import to fix https regex []

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "cli-table3": "^0.6.0",
         "command-exists": "^1.2.7",
         "contentful-export": "^7.19.0",
-        "contentful-import": "^8.5.28",
+        "contentful-import": "^8.5.35",
         "contentful-management": "^10.12.1",
         "contentful-migration": "^4.12.5",
         "emojic": "^1.1.11",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "cli-table3": "^0.6.0",
     "command-exists": "^1.2.7",
     "contentful-export": "^7.19.0",
-    "contentful-import": "^8.5.28",
+    "contentful-import": "^8.5.35",
     "contentful-management": "^10.12.1",
     "contentful-migration": "^4.12.5",
     "emojic": "^1.1.11",


### PR DESCRIPTION
This PR in `contentful-import` fixes an error where you can get 422 when uploading assets https://github.com/contentful/contentful-import/pull/747/files.
This is just the bump to use that version of the package