### PR TITLE
docs: fixes on the merge subcommand docs []

### DIFF
--- a/docs/merge/README.md
+++ b/docs/merge/README.md
@@ -1,6 +1,11 @@
 # Contentful CLI - Merge command
 
+This subcommand brings in some of the functionality from the [Merge App](https://www.contentful.com/marketplace/app/merge/) into the CLI.
+It allows developers to programatically view and export the diff between content types similarly to how the Merge App does it.
+
+One of the functionalities not yet here is merging as you can do it with [contentful-migration](https://github.com/contentful/contentful-migration/blob/master/README.md#reference-documentation)
+
 ## Available sub-commands:
 
-- [show](./show) - Show diff between two environments.
-- [export](./export) - Export diff between two environments as a migration.
+- [show](./show) - Show diff in content types between two environments.
+- [export](./export) - Export diff between in content types two environments as a migration.

--- a/docs/merge/export/README.md
+++ b/docs/merge/export/README.md
@@ -1,6 +1,6 @@
 # Contentful CLI - `merge export` command
 
-Export diff between two environments as a migration.
+Export diff in content types between two environments as a migration.
 
 ## Usage
 
@@ -10,6 +10,8 @@ Options:
   -h, --help                     Show help                             [boolean]
   --source-environment-id, --se  Source environment id       [string] [required]
   --target-environment-id, --te  Target environment id       [string] [required]
+  --space-id, -s                 ID of the space that holds the environment
+                                                                        [string]
   --yes, -y                      Confirm Merge app installation without prompt
   --output-file, -o              Output file. It defaults to
                                  ./migrations/<timestamp>-<space-id>-<source-env

--- a/docs/merge/show/README.md
+++ b/docs/merge/show/README.md
@@ -1,6 +1,6 @@
 # Contentful CLI - `merge show` command
 
-Show diff between two environments.
+Show diff in content types between two environments.
 
 ## Usage
 
@@ -10,6 +10,8 @@ Options:
   -h, --help                     Show help                             [boolean]
   --source-environment-id, --se  Source environment id       [string] [required]
   --target-environment-id, --te  Target environment id       [string] [required]
+  --space-id, -s                 ID of the space that holds the environment
+                                                                        [string]
   --yes, -y                      Confirm Merge app installation without prompt
 ```
 

--- a/lib/cmds/merge_cmds/export.ts
+++ b/lib/cmds/merge_cmds/export.ts
@@ -31,6 +31,11 @@ module.exports.builder = (yargs: Argv) => {
       demandOption: true,
       describe: 'Target environment id'
     })
+    .option('space-id', {
+      alias: 's',
+      describe: 'ID of the space that holds the environment',
+      type: 'string'
+    })
     .option('yes', {
       alias: 'y',
       describe: 'Confirm Merge app installation without prompt'

--- a/lib/cmds/merge_cmds/show.ts
+++ b/lib/cmds/merge_cmds/show.ts
@@ -5,14 +5,8 @@ import {
 } from '@contentful/app-action-utils'
 import { PlainClientAPI } from 'contentful-management'
 import type { Argv } from 'yargs'
-import {
-  getAppActionId,
-  getAppDefinitionId,
-  Host
-} from '../../utils/app-actions-config'
-import { checkAndInstallAppInEnvironments } from '../../utils/app-installation'
+import { getAppActionId, Host } from '../../utils/app-actions-config'
 import { handleAsyncError as handle } from '../../utils/async'
-import { createPlainClient } from '../../utils/contentful-clients'
 import { ContentTypeApiHelper } from '../../utils/merge/content-type-api-helper'
 import { prepareMergeCommand } from '../../utils/merge/prepare-merge-command'
 import { printChangesetMessages } from '../../utils/merge/print-changeset-messages'
@@ -36,6 +30,11 @@ module.exports.builder = (yargs: Argv) => {
       type: 'string',
       demandOption: true,
       describe: 'Target environment id'
+    })
+    .option('space-id', {
+      alias: 's',
+      describe: 'ID of the space that holds the environment',
+      type: 'string'
     })
     .option('yes', {
       alias: 'y',


### PR DESCRIPTION
- Adds a bit more clarity about the `merge` subcommand and the intentions of it. 
- Specifically adds the `space-id` option in the commands so it gets shown in the help of the commands. This was already present as that option is global but it didn't show on help
