### PR TITLE
fix(): correct version being used in CLI package [PHX-2553]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,8 @@ jobs:
       - run: git fetch --tags
       - run: npm ci
       - run: npm run tsc
-      - run: npm run build:package
+      # The build is automatically executed in a prepublishOnly script to ensure that the package.json with the updated version
+      # is being packaged
       - run: npm run semantic-release
   audit:
     docker: &ref_0

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:e2e": "JEST_SUITE_NAME=\"Unit Tests\" JEST_JUNIT_OUTPUT_NAME=\"e2e-tests.xml\" cross-env jest --testPathPattern=test/e2e --verbose",
     "precommit": "npm run prettier:write && lint-staged",
     "prepush": "jest --changedSince master test/unit/**",
-    "prepublishOnly": "npm run build:standalone",
+    "prepublishOnly": "npm run build:package",
     "prettier": "prettier --config .prettierrc \"./*.js\" \"{./lib,./test,./docs,.}/**/*.{js,json,md}\"",
     "prettier:write": "npm run prettier -- --write",
     "prettier:debug": "npm run prettier -- --debug-check",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:e2e": "JEST_SUITE_NAME=\"Unit Tests\" JEST_JUNIT_OUTPUT_NAME=\"e2e-tests.xml\" cross-env jest --testPathPattern=test/e2e --verbose",
     "precommit": "npm run prettier:write && lint-staged",
     "prepush": "jest --changedSince master test/unit/**",
+    "prepublishOnly": "npm run build:standalone",
     "prettier": "prettier --config .prettierrc \"./*.js\" \"{./lib,./test,./docs,.}/**/*.{js,json,md}\"",
     "prettier:write": "npm run prettier -- --write",
     "prettier:debug": "npm run prettier -- --debug-check",


### PR DESCRIPTION

## Summary

There have been problems with printing out the package version https://github.com/contentful/contentful-cli/issues/1800

This PR moves the building of the package to the prePublishOnly script so that the version is correctly set by semantic-release before it is bundled up. 

