### PR TITLE
feat: only show content type changes in merge show command [PHX-2514]

### DIFF
--- a/lib/cmds/merge_cmds/show.ts
+++ b/lib/cmds/merge_cmds/show.ts
@@ -140,7 +140,17 @@ const showEnvironmentChangeset = async ({
       sourceEnvironmentId,
       targetEnvironmentId
     })
-  const message = printChangesetMessages(targetContentType, changeset)
+
+  // We show only content type changes for now.
+  // This filter can be removed once we support editor interfaces.
+  const contentTypeChangeset = changeset.filter(
+    changesetItem => changesetItem.entity.sys.linkType === 'ContentType'
+  )
+
+  const message = printChangesetMessages(
+    targetContentType,
+    contentTypeChangeset
+  )
   console.log(message)
 }
 

--- a/lib/utils/merge/types.ts
+++ b/lib/utils/merge/types.ts
@@ -32,7 +32,7 @@ export type Operation =
 type EntityLink = {
   sys: {
     id: string
-    linkType: string
+    linkType: 'ContentType' | 'EditorInterface'
     type: 'Link'
   }
 }


### PR DESCRIPTION
Temporary filter to only show content type changes, while editor interfaces are not supported yet.