### PR TITLE
fix: proxy agent import [PHX-2711]

### DIFF
--- a/lib/utils/proxy.js
+++ b/lib/utils/proxy.js
@@ -1,6 +1,6 @@
 const { parse, format } = require('url')
 const { toInteger } = require('lodash')
-const HttpsProxyAgent = require('https-proxy-agent')
+const { HttpsProxyAgent } = require('https-proxy-agent')
 
 function serializeAuth({ username, password } = {}) {
   if (!username) {

--- a/test/proxy/client.js
+++ b/test/proxy/client.js
@@ -1,5 +1,5 @@
 const { createClient } = require('contentful-management')
-const HttpsProxyAgent = require('https-proxy-agent')
+const { HttpsProxyAgent } = require('https-proxy-agent')
 const { ssl, space, token } = require('yargs').argv
 
 const envKeys = ['http_proxy', 'https_proxy']


### PR DESCRIPTION
Since the last upgrade of `https-proxy-agent` dependency it is being imported incorrectly thus causing an error on proxy setup when not using `rawProxy: true`

<img width="588" alt="Screenshot 2023-06-23 at 14 53 10" src="https://github.com/contentful/contentful-cli/assets/4799048/f10de758-201e-4d31-bd54-71fe77e534b5">
