### PR TITLE
chore: inform on actual engine compatibility (>= 16)

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "yargs": "~13.3.2"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=16"
   },
   "files": [
     "dist",


### PR DESCRIPTION
I am pretty sure >= 8 is already not working anymore.