### PR TITLE
feat: show moves in merge show command output [PHX-2582]

### DIFF
--- a/lib/utils/merge/create-merge-message.ts
+++ b/lib/utils/merge/create-merge-message.ts
@@ -47,6 +47,9 @@ const valueTypeFormatter = (value: string | number | boolean) => {
   return value
 }
 
+const arrowSymbol = (direction: 'up' | 'down') =>
+  direction === 'up' ? '↑' : '↓'
+
 const Formatter = {
   type: (value: string) => chalk.bold(value),
   id: (value: string) => chalk.yellow(value),
@@ -186,13 +189,17 @@ export function createMessageLogStructure(
 
         if (isMoveOperation) {
           if (isNestedMove) {
-            messages.push(Formatter.record(`position: order changed`))
+            messages.push(Formatter.record(`position: ↕ order changed`))
           } else {
             const fromIndex = getLastIndexFromPath(operation.from)
             const toIndex = getLastIndexFromPath(operation.path)
             const direction = fromIndex < toIndex ? 'down' : 'up'
 
-            messages.push(Formatter.record(`position: moved ${direction}`))
+            messages.push(
+              Formatter.record(
+                `position: ${arrowSymbol(direction)} moved ${direction}`
+              )
+            )
           }
         }
 

--- a/lib/utils/merge/create-merge-message.ts
+++ b/lib/utils/merge/create-merge-message.ts
@@ -8,6 +8,7 @@ import {
   getChangeKey,
   getFieldIdForIndex,
   getLastIndexFromPath,
+  getNestedPropertyNames,
   isNestedMoveOperation
 } from './utils'
 
@@ -147,12 +148,24 @@ export function createMessageLogStructure(
         }
 
         const fieldValueChange = fieldChange(operation)
-        if (fieldValueChange && fieldValueChange.length > 0) {
-          messages.push(
-            Formatter.record(
-              `property: ${Formatter.property(fieldValueChange)}`
+        const isNestedMove = isNestedMoveOperation(operation)
+
+        if (fieldValueChange) {
+          if (isNestedMove) {
+            const propChain = getNestedPropertyNames(operation)
+
+            messages.push(
+              Formatter.record(
+                `property: ${Formatter.property(propChain.join(' -> '))}`
+              )
             )
-          )
+          } else if (fieldValueChange.length > 0) {
+            messages.push(
+              Formatter.record(
+                `property: ${Formatter.property(fieldValueChange)}`
+              )
+            )
+          }
         }
 
         if (isChangeOperation) {
@@ -172,7 +185,7 @@ export function createMessageLogStructure(
         }
 
         if (isMoveOperation) {
-          if (isNestedMoveOperation(operation)) {
+          if (isNestedMove) {
             messages.push(Formatter.record(`position: order changed`))
           } else {
             const fromIndex = getLastIndexFromPath(operation.from)

--- a/lib/utils/merge/render-changeset-messages.ts
+++ b/lib/utils/merge/render-changeset-messages.ts
@@ -14,7 +14,8 @@ function StringRenderer({ indentString = spacer.repeat(2) }) {
 const ChangeTypeToIndicatorMap: Record<string, string> = {
   add: '+Added',
   delete: '-Deleted',
-  update: '~Changed'
+  update: '~Changed',
+  move: '~Changed'
 }
 export function renderChangesetMessages(messages: Message[]): string {
   const renderer = StringRenderer({})

--- a/lib/utils/merge/utils.ts
+++ b/lib/utils/merge/utils.ts
@@ -20,11 +20,11 @@ export const getFieldIdForIndex = (
   return 'unknown'
 }
 
-export const fieldIndex = (operation: Operation): number => {
-  if (!operation.path.startsWith('/fields')) {
+export const fieldIndex = (path: string): number => {
+  if (!path.startsWith('/fields')) {
     return -1
   }
-  return parseInt(operation.path.split('/')[2])
+  return parseInt(path.split('/')[2])
 }
 
 export const fieldChange = (operation: Operation): string => {
@@ -32,4 +32,16 @@ export const fieldChange = (operation: Operation): string => {
     return ''
   }
   return operation.path.split('/')[3]
+}
+
+export const isNestedMoveOperation = (operation: Operation): boolean => {
+  return (
+    operation.op === 'move' &&
+    operation.path.split('/').filter(x => x !== '').length > 2
+  )
+}
+
+export const getLastIndexFromPath = (path: string) => {
+  const stringIndex = path.split('/').pop() as string
+  return parseInt(stringIndex, 10) || 0
 }

--- a/lib/utils/merge/utils.ts
+++ b/lib/utils/merge/utils.ts
@@ -34,6 +34,8 @@ export const fieldChange = (operation: Operation): string => {
   return operation.path.split('/')[3]
 }
 
+// Util functions for move operations
+
 export const isNestedMoveOperation = (operation: Operation): boolean => {
   return (
     operation.op === 'move' &&
@@ -41,7 +43,17 @@ export const isNestedMoveOperation = (operation: Operation): boolean => {
   )
 }
 
-export const getLastIndexFromPath = (path: string) => {
+export const getLastIndexFromPath = (path: string): number => {
   const stringIndex = path.split('/').pop() as string
-  return parseInt(stringIndex, 10) || 0
+  const lastIndex = parseInt(stringIndex, 10)
+  if (isNaN(lastIndex)) {
+    return -1
+  }
+  return lastIndex
 }
+
+export const getNestedPropertyNames = (operation: Operation) =>
+  operation.path
+    .split('/')
+    // we want any property that is within fields, we filter out indices
+    .filter(x => x !== 'fields' && x !== '' && isNaN(parseInt(x, 10)))

--- a/test/unit/utils/merge/merge-mock.ts
+++ b/test/unit/utils/merge/merge-mock.ts
@@ -63,8 +63,8 @@ export const ContentModel = [
         omitted: false
       },
       {
-        id: 'firstContentType',
-        name: 'first content type',
+        id: 'some-field',
+        name: 'some field',
         type: 'Link',
         localized: false,
         required: false,

--- a/test/unit/utils/merge/merge-mock.ts
+++ b/test/unit/utils/merge/merge-mock.ts
@@ -97,6 +97,21 @@ export const ContentModel = [
         validations: [],
         disabled: false,
         omitted: false
+      },
+      {
+        id: 'rich',
+        name: 'rich',
+        type: 'RichText',
+        localized: false,
+        required: false,
+        validations: [
+          {
+            enabledMarks: ['bold', 'italic', 'underline', 'code'],
+            message: 'Only bold, underline, code, and italic marks are allowed'
+          }
+        ],
+        disabled: false,
+        omitted: false
       }
     ]
   },
@@ -394,6 +409,16 @@ export const ChangesetItemsMock: ChangesetItem[] = [
         op: 'replace',
         path: '/fields/3/omitted',
         value: true
+      },
+      {
+        op: 'move',
+        from: '/fields/1/validations/0',
+        path: '/fields/1/validations/1'
+      },
+      {
+        op: 'move',
+        from: '/fields/4/validations/0/enabledMarks/1',
+        path: '/fields/4/validations/0/enabledMarks/3'
       },
       { op: 'move', from: '/fields/0', path: '/fields/1' },
       { op: 'move', from: '/fields/3', path: '/fields/2' }

--- a/test/unit/utils/merge/merge-mock.ts
+++ b/test/unit/utils/merge/merge-mock.ts
@@ -394,7 +394,9 @@ export const ChangesetItemsMock: ChangesetItem[] = [
         op: 'replace',
         path: '/fields/3/omitted',
         value: true
-      }
+      },
+      { op: 'move', from: '/fields/0', path: '/fields/1' },
+      { op: 'move', from: '/fields/3', path: '/fields/2' }
     ]
   },
   {

--- a/test/unit/utils/merge/print-changeset-messages.test.ts
+++ b/test/unit/utils/merge/print-changeset-messages.test.ts
@@ -39,7 +39,7 @@ describe('A print changeset messages function', () => {
 
   ~Changed
    type: Field
-   id: firstContentType
+   id: some-field
    property: validations
    position: order changed
 

--- a/test/unit/utils/merge/print-changeset-messages.test.ts
+++ b/test/unit/utils/merge/print-changeset-messages.test.ts
@@ -39,6 +39,18 @@ describe('A print changeset messages function', () => {
 
   ~Changed
    type: Field
+   id: firstContentType
+   property: validations
+   position: order changed
+
+  ~Changed
+   type: Field
+   id: rich
+   property: validations -> enabledMarks
+   position: order changed
+
+  ~Changed
+   type: Field
    id: name
    position: moved down
 

--- a/test/unit/utils/merge/print-changeset-messages.test.ts
+++ b/test/unit/utils/merge/print-changeset-messages.test.ts
@@ -41,23 +41,23 @@ describe('A print changeset messages function', () => {
    type: Field
    id: some-field
    property: validations
-   position: order changed
+   position: ↕ order changed
 
   ~Changed
    type: Field
    id: rich
    property: validations -> enabledMarks
-   position: order changed
+   position: ↕ order changed
 
   ~Changed
    type: Field
    id: name
-   position: moved down
+   position: ↓ moved down
 
   ~Changed
    type: Field
    id: salePrice
-   position: moved up
+   position: ↑ moved up
 
 ~Changed
  type: ContentType

--- a/test/unit/utils/merge/print-changeset-messages.test.ts
+++ b/test/unit/utils/merge/print-changeset-messages.test.ts
@@ -37,6 +37,16 @@ describe('A print changeset messages function', () => {
    property: omitted
    value: true
 
+  ~Changed
+   type: Field
+   id: name
+   position: moved down
+
+  ~Changed
+   type: Field
+   id: salePrice
+   position: moved up
+
 ~Changed
  type: ContentType
  id: firstContentType


### PR DESCRIPTION

## Summary

During the `merge show` command, move operations are now also displayed.

## Description
For field moves, we indicate the direction (up or down). 
For more deeply nested moves, we indicate that the order has changed and list the (nested) properties.

## Screenshot:

The screenshot shows the following cases: 
- nested property has order changes
- deeply nested property has order changes
- field was moved up
- field was moved down

<img width="512" alt="image" src="https://github.com/contentful/contentful-cli/assets/33579339/a8e38cea-c8a8-454a-bd41-7d5b56f1797a">
