### PR TITLE
chore(): update xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,8 @@ jobs:
           path: ./reports/e2e-tests.xml
   osx:
     macos:
-      xcode: 14.2.0
-    resource_class: macos.m1.medium.gen1
+      xcode: 14.3.1
+    resource_class: macos.x86.medium.gen2
     steps:
       - run: node --version
       - run: npm --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,8 @@ jobs:
           path: ./reports/e2e-tests.xml
   osx:
     macos:
-      xcode: 14.3.1
+      xcode: 14.2.0
+    resource_class: macos.m1.medium.gen1
     steps:
       - run: node --version
       - run: npm --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           path: ./reports/e2e-tests.xml
   osx:
     macos:
-      xcode: 12.5.1
+      xcode: 14.3.1
     steps:
       - run: node --version
       - run: npm --version


### PR DESCRIPTION
Updating the Xcode version & adding a Gen2 resource class because CircleCI is deprecating MacOS intel Gen1.
This one [will be deprecated in January 2024](https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718), so by then we'll have to switch to a silicon mac resource class.