### PR TITLE
feat: use host in login [PHX-2805]

### DIFF
--- a/lib/cmds/login.ts
+++ b/lib/cmds/login.ts
@@ -12,8 +12,18 @@ import { copyright } from '../utils/copyright'
 
 const APP_ID =
   '9f86a1d54f3d6f85c159468f5919d6e5d27716b3ed68fd01bd534e3dea2df864'
-const REDIRECT_URI = 'https://www.contentful.com/developers/cli-oauth-page/'
-const oAuthURL = `https://be.contentful.com/oauth/authorize?response_type=token&client_id=${APP_ID}&redirect_uri=${REDIRECT_URI}&scope=content_management_manage&action=cli`
+
+export const getOauthURL = (host?: string) => {
+  const REDIRECT_URI = 'https://www.contentful.com/developers/cli-oauth-page/'
+  let oAuthURL = `https://be.contentful.com/oauth/authorize?response_type=token&client_id=${APP_ID}&redirect_uri=${REDIRECT_URI}&scope=content_management_manage&action=cli`
+
+  if (host) {
+    const url = host.replace('api.', '')
+    oAuthURL = `https://be.${url}/oauth/authorize?response_type=token&client_id=${APP_ID}&redirect_uri=${REDIRECT_URI}&scope=content_management_manage&action=cli`
+  }
+
+  return oAuthURL
+}
 
 export const command = 'login'
 
@@ -37,6 +47,7 @@ export const builder = (yargs: Argv) =>
 
 interface Context {
   managementToken?: string
+  host?: string
 }
 
 interface LoginProps {
@@ -48,7 +59,7 @@ export const login = async ({
   context,
   managementToken: managementTokenFlag
 }: LoginProps) => {
-  const { managementToken } = context
+  const { managementToken, host } = context
 
   let token
   if (managementTokenFlag) {
@@ -82,6 +93,8 @@ export const login = async ({
       return
     }
 
+    const oAuthURL = getOauthURL(host)
+    
     // We open the browser window only on Windows and OSX since this might fail or open the wrong browser on Linux.
     if (['win32', 'darwin'].includes(process.platform)) {
       await open(oAuthURL, {

--- a/test/unit/cmds/login.test.ts
+++ b/test/unit/cmds/login.test.ts
@@ -48,6 +48,36 @@ test('login - without error', async () => {
   expect(result).toBe(mockedRcConfig.managementToken)
 })
 
+test('login - uses host from config', async () => {
+  await loginHandler({
+    context: {
+      host: 'api.eu.contentful.com'
+    }
+  })
+
+  if (['win32', 'darwin'].includes(process.platform)) {
+    expect(open).toHaveBeenCalled()
+    expect(
+      mocks.open.mock.calls[0][0].includes(
+        'https://be.eu.contentful.com/oauth/'
+      )
+    ).toBeTruthy()
+  }
+})
+
+test('login - uses default host without host in config', async () => {
+  await loginHandler({
+    context: {}
+  })
+
+  if (['win32', 'darwin'].includes(process.platform)) {
+    expect(open).toHaveBeenCalled()
+    expect(
+      mocks.open.mock.calls[0][0].includes('https://be.contentful.com/oauth')
+    ).toBeTruthy()
+  }
+})
+
 test('login - user abort', async () => {
   mocks.confirmation.mockResolvedValueOnce(false)
 


### PR DESCRIPTION
### Summary

Use host from config in login command, this will allow users to login to EU accounts via CLI
