### PR TITLE
chore: bump 'release' CI job node version to make it compatible with semantic-release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           path: ./reports/e2e-tests.xml
   release:
     docker:
-      - image: cimg/node:18.18.0
+      - image: cimg/node:21.6.1
     steps:
       - checkout
       - vault/get-secrets: # Loads vault secrets


### PR DESCRIPTION
## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->
See https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md - the "release" CI job that executes semantic-release requires a node version >=20.8.1. 

## Description

<!-- Describe your changes in detail -->

I don't believe it is necessary to update the other jobs to this node version at this time, just this one should be sufficient.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

master builds have been stuck due to this issue


