### PR TITLE
fix (space migrations): bump contentful-migration to allow migrations for EU spaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "contentful-export": "^7.19.0",
         "contentful-import": "^9.0.0",
         "contentful-management": "^11.0.1",
-        "contentful-migration": "^4.16.0",
+        "contentful-migration": "^4.20.0",
         "emojic": "^1.1.11",
         "execa": "^5.0.0",
         "figlet": "^1.2.0",
@@ -6437,9 +6437,9 @@
       }
     },
     "node_modules/contentful-migration": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/contentful-migration/-/contentful-migration-4.19.1.tgz",
-      "integrity": "sha512-CRkFuEZwuJBOUyG8TYlDwGOaQ9Cu6L82CJ5YxQ9aIsNKWWn0BPA/kLUl26/zTYqUsYUM0gRO0+Eh3I5atZcuPg==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/contentful-migration/-/contentful-migration-4.20.0.tgz",
+      "integrity": "sha512-/ArjAAsK7ImpTl9mJGXg8uwyrVFJz25O8nsIgvC+841FcH/MSypo9cJhtevXgVb7cOx80NV/WVtKzsGeKouoDw==",
       "dependencies": {
         "@hapi/hoek": "^11.0.4",
         "axios": "^1.6.2",
@@ -27424,9 +27424,9 @@
       }
     },
     "contentful-migration": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/contentful-migration/-/contentful-migration-4.19.1.tgz",
-      "integrity": "sha512-CRkFuEZwuJBOUyG8TYlDwGOaQ9Cu6L82CJ5YxQ9aIsNKWWn0BPA/kLUl26/zTYqUsYUM0gRO0+Eh3I5atZcuPg==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/contentful-migration/-/contentful-migration-4.20.0.tgz",
+      "integrity": "sha512-/ArjAAsK7ImpTl9mJGXg8uwyrVFJz25O8nsIgvC+841FcH/MSypo9cJhtevXgVb7cOx80NV/WVtKzsGeKouoDw==",
       "requires": {
         "@hapi/hoek": "^11.0.4",
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "contentful-export": "^7.19.0",
     "contentful-import": "^9.0.0",
     "contentful-management": "^11.0.1",
-    "contentful-migration": "^4.16.0",
+    "contentful-migration": "^4.20.0",
     "emojic": "^1.1.11",
     "execa": "^5.0.0",
     "figlet": "^1.2.0",


### PR DESCRIPTION
## Summary

Previous attempts at enabling users to override the default API `host` for EU data residency purposes, did not propagate the changes to the downstream `contentful-migration` tool. That functionality was added to `contentful-migration` [here](https://github.com/contentful/contentful-migration/pull/1286) and released in version 4.20.0, so we're bumping our dependency to that version.
