### PR TITLE
fix: seed "mkdirp is not a function" []

### DIFF
--- a/lib/utils/github.js
+++ b/lib/utils/github.js
@@ -4,7 +4,7 @@ const zlib = require('zlib')
 const axios = require('axios')
 const Listr = require('listr')
 const tar = require('tar')
-const mkdirp = require('mkdirp')
+const {mkdirp} = require('mkdirp')
 
 function getLatestGitHubRelease(repo, destination) {
   return new Listr([


### PR DESCRIPTION
## Summary

`contentful space seed` currently throw the following error : 
```
🚨  Error: mkdirp is not a function
```
Related issue : https://github.com/contentful/contentful-cli/issues/1978

## Description

Impossible to run seed command

## Motivation and Context

This PR fix this issue and make the function actually works