### PR TITLE
feat: organization export 

### DIFF
--- a/docs/organization/README.md
+++ b/docs/organization/README.md
@@ -3,3 +3,4 @@
 ## Available subcommands:
 
 - [list](./list) - List all Organizations you have access to
+- [export](./export) - Export a organization data to a json file

--- a/docs/organization/export/README.md
+++ b/docs/organization/export/README.md
@@ -7,7 +7,7 @@ This command helps you export organization data to a json file
 ```
 contentful organization export
 
-export a space data to a json file
+export an organization's data to a json file
 
 Options:
   -h, --help                Show help                                    [boolean]

--- a/docs/organization/export/README.md
+++ b/docs/organization/export/README.md
@@ -1,0 +1,36 @@
+# Contentful CLI - `organization export` command
+
+This command helps you export organization data to a json file
+
+## Usage
+
+```
+contentful organization export
+
+export a space data to a json file
+
+Options:
+  -h, --help                Show help                                    [boolean]
+  --organization-id         ID of organization                             [string]
+
+  --save-file               Save the export as a json file
+                                                         [boolean] [default: true]
+
+  --header                  Pass an additional HTTP Header
+  --output-file             Output file.
+                                        [string] [default: ./migrations/<timestamp>-<organization-id>.json]
+```
+
+### Example
+
+```sh
+contentful organization export
+```
+
+## Exported data
+
+```js
+{
+  "taxonomy": {"concepts": [], "conceptSchemes": []},
+}
+```

--- a/docs/organization/export/README.md
+++ b/docs/organization/export/README.md
@@ -16,6 +16,9 @@ Options:
   --save-file               Save the export as a json file
                                                          [boolean] [default: true]
 
+  --silent                  Suppress any log output
+                                                         [boolean] [default: false]
+
   --header                  Pass an additional HTTP Header
   --output-file             Output file.
                                         [string] [default: ./migrations/<timestamp>-<organization-id>.json]

--- a/lib/cmds/organization_cmds/export.ts
+++ b/lib/cmds/organization_cmds/export.ts
@@ -8,7 +8,7 @@ import { copyright } from '../../utils/copyright'
 import { cursorPaginate } from '../../utils/cursor-pagninate'
 import { ensureDir, getPath, writeFileP } from '../../utils/fs'
 import { getHeadersFromOption } from '../../utils/headers'
-import { success } from '../../utils/log'
+import { success, log } from '../../utils/log'
 
 module.exports.command = 'export'
 
@@ -112,7 +112,12 @@ async function organizationExport({
 
   const result = await tasks.run({ concepts: [], conceptSchemes: [] })
 
-  await writeFileP(outputTarget, JSON.stringify(result, null, 2))
+  if (outputFile) {
+    await writeFileP(outputTarget, JSON.stringify(result, null, 2))
+  } else {
+    log(JSON.stringify(result, null, 2))
+  }
+
   success(`✅ Organization data exported to ${outputTarget}`)
 }
 

--- a/lib/cmds/organization_cmds/export.ts
+++ b/lib/cmds/organization_cmds/export.ts
@@ -84,7 +84,7 @@ async function organizationExport({
           {
             title: 'Exporting Concepts',
             task: async () => {
-              ctx.concepts = await cursorPaginate({
+              ctx.taxonomy.concepts = await cursorPaginate({
                 queryPage: pageUrl =>
                   client.concept.getMany({
                     organizationId,
@@ -96,7 +96,7 @@ async function organizationExport({
           {
             title: 'Exporting Concept Schemes',
             task: async () => {
-              ctx.conceptSchemes = await cursorPaginate({
+              ctx.taxonomy.conceptSchemes = await cursorPaginate({
                 queryPage: pageUrl =>
                   client.conceptScheme.getMany({
                     organizationId,
@@ -110,7 +110,9 @@ async function organizationExport({
     }
   ])
 
-  const result = await tasks.run({ concepts: [], conceptSchemes: [] })
+  const result = await tasks.run({
+    taxonomy: { concepts: [], conceptSchemes: [] }
+  })
 
   if (outputFile) {
     await writeFileP(outputTarget, JSON.stringify(result, null, 2))

--- a/lib/cmds/organization_cmds/export.ts
+++ b/lib/cmds/organization_cmds/export.ts
@@ -39,6 +39,11 @@ module.exports.builder = (yargs: Argv) => {
       describe:
         'Output file. It defaults to ./migrations/<timestamp>-<organization-id>.json'
     })
+    .option('save-file', {
+      describe: 'Save the export as a json file',
+      type: 'boolean',
+      default: true
+    })
     .epilog(
       [
         'See more at:',
@@ -53,13 +58,15 @@ interface Params {
   header?: string
   organizationId: string
   outputFile?: string
+  saveFile?: boolean
 }
 
 async function organizationExport({
   context,
   header,
   organizationId,
-  outputFile
+  outputFile,
+  saveFile
 }: Params) {
   const { managementToken } = context
 
@@ -114,7 +121,7 @@ async function organizationExport({
     taxonomy: { concepts: [], conceptSchemes: [] }
   })
 
-  if (outputFile) {
+  if (saveFile) {
     await writeFileP(outputTarget, JSON.stringify(result, null, 2))
   } else {
     log(JSON.stringify(result, null, 2))

--- a/lib/cmds/organization_cmds/export.ts
+++ b/lib/cmds/organization_cmds/export.ts
@@ -1,0 +1,123 @@
+import Listr from 'listr'
+import { noop } from 'lodash'
+import path from 'path'
+import type { Argv } from 'yargs'
+import { handleAsyncError as handle } from '../../utils/async'
+import { createPlainClient } from '../../utils/contentful-clients'
+import { copyright } from '../../utils/copyright'
+import { cursorPaginate } from '../../utils/cursor-pagninate'
+import { ensureDir, getPath, writeFileP } from '../../utils/fs'
+import { getHeadersFromOption } from '../../utils/headers'
+import { success } from '../../utils/log'
+
+module.exports.command = 'export'
+
+module.exports.desc = 'export your organization entities'
+
+module.exports.builder = (yargs: Argv) => {
+  return yargs
+    .usage('Usage: contentful organization export')
+    .option('management-token', {
+      alias: 'mt',
+      describe: 'Contentful management API token',
+      type: 'string'
+    })
+    .option('organization-id', {
+      alias: 'oid',
+      describe: 'ID of Organization with source data',
+      type: 'string',
+      demandOption: true
+    })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass an additional HTTP Header'
+    })
+    .option('output-file', {
+      alias: 'o',
+      type: 'string',
+      describe:
+        'Output file. It defaults to ./migrations/<timestamp>-<organization-id>.json'
+    })
+    .epilog(
+      [
+        'See more at:',
+        'https://github.com/contentful/contentful-cli/tree/master/docs/organization/export',
+        copyright
+      ].join('\n')
+    )
+}
+
+interface Params {
+  context: { managementToken: string }
+  header?: string
+  organizationId: string
+  outputFile?: string
+}
+
+async function organizationExport({
+  context,
+  header,
+  organizationId,
+  outputFile
+}: Params) {
+  const { managementToken } = context
+
+  const client = await createPlainClient({
+    accessToken: managementToken,
+    feature: 'organization-export',
+    headers: getHeadersFromOption(header),
+    throttle: 8,
+    logHandler: noop
+  })
+
+  const outputTarget = getPath(
+    outputFile || path.join('data', `${Date.now()}-${organizationId}.json`)
+  )
+  await ensureDir(path.dirname(outputTarget))
+
+  const tasks = new Listr([
+    {
+      title: 'Exporting Organization',
+      task: async ctx => {
+        return new Listr([
+          {
+            title: 'Exporting Concepts',
+            task: async () => {
+              ctx.concepts = await cursorPaginate({
+                queryPage: pageUrl =>
+                  client.concept.getMany({
+                    organizationId,
+                    query: { pageUrl }
+                  })
+              })
+            }
+          },
+          {
+            title: 'Exporting Concept Schemes',
+            task: async () => {
+              ctx.conceptSchemes = await cursorPaginate({
+                queryPage: pageUrl =>
+                  client.conceptScheme.getMany({
+                    organizationId,
+                    query: { pageUrl }
+                  })
+              })
+            }
+          }
+        ])
+      }
+    }
+  ])
+
+  const result = await tasks.run({ concepts: [], conceptSchemes: [] })
+
+  await writeFileP(outputTarget, JSON.stringify(result, null, 2))
+  success(`✅ Organization data exported to ${outputTarget}`)
+}
+
+module.exports.organizationExport = organizationExport
+
+module.exports.handler = handle(organizationExport)
+
+export default organizationExport

--- a/lib/config.js
+++ b/lib/config.js
@@ -16,6 +16,7 @@ module.exports = {
     'login',
     'feedback',
     'organization list',
+    'organization export',
     'space create',
     'space list',
     'space use'

--- a/lib/utils/cursor-pagninate.ts
+++ b/lib/utils/cursor-pagninate.ts
@@ -1,0 +1,21 @@
+import { CursorPaginatedCollectionProp } from 'contentful-management/dist/typings/common-types'
+
+export async function cursorPaginate<T>({
+  queryPage
+}: {
+  queryPage: (pageUrl?: string) => Promise<CursorPaginatedCollectionProp<T>>
+}): Promise<Array<T>> {
+  // Fetch the first page
+  const data = await queryPage()
+  const { pages, items } = data
+
+  let nextPage = pages?.next
+
+  while (nextPage) {
+    const next = await queryPage(nextPage)
+    items.push(...next.items)
+    nextPage = next.pages?.next
+  }
+
+  return items
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4291,9 +4291,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.6.tgz",
+      "integrity": "sha512-/d7Rnj0/ExXDMcioS78/kf1lMzYk4BZV8MZGTBKzTGZ6/406ukkbYlIsZmMPhcR5KlkunDHQLrtAVmSq7r+mSw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4285,15 +4285,15 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-YpS0zzoduEhuOWjAotS6A5AVCva7X4lVlYLF0FYHAY9sdraBfnatttHItlWeZdGhuEkf+OzMNg2ZYAx8t+52uQ==",
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.12.tgz",
+      "integrity": "sha512-sviUmCE8AYdaF/KIHLDJBQgeYzPBI0vf/17NaYehBJfYD1j6/L95Slh07NlyK2iNyBNaEkb3En2jRt+a8y3xZQ==",
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.6.tgz",
-      "integrity": "sha512-/d7Rnj0/ExXDMcioS78/kf1lMzYk4BZV8MZGTBKzTGZ6/406ukkbYlIsZmMPhcR5KlkunDHQLrtAVmSq7r+mSw==",
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.7.tgz",
+      "integrity": "sha512-SRxCrrg9CL/y54aiMCG3edPKdprgMVGDXjA3gB8UmmBW5TcXzRUYAh8EWzTnSJFAd1rgImPELza+A3bJ+qxz8Q==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -19460,9 +19460,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semantic-release": {
-      "version": "24.1.2",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-24.1.2.tgz",
-      "integrity": "sha512-hvEJ7yI97pzJuLsDZCYzJgmRxF8kiEJvNZhf0oiZQcexw+Ycjy4wbdsn/sVMURgNCu8rwbAXJdBRyIxM4pe32g==",
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-24.1.3.tgz",
+      "integrity": "sha512-Cb0Pm3Ye15u8k/B+7EnusMUSIIucAIEBD3QDRmmclv53KVyqmg1Lb3XPx0AMNxfJZEI+ZT+M+IXDyTrudK6Rew==",
       "dev": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.0-beta.1",

--- a/test/integration/cmds/organization/__snapshots__/export.test.ts.snap
+++ b/test/integration/cmds/organization/__snapshots__/export.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`organization export snapshots should print help message: help data is correct 1`] = `
+exports[`organization export should print help message: help data is correct 1`] = `
 "Usage: contentful organization export
 
 Options:

--- a/test/integration/cmds/organization/__snapshots__/export.test.ts.snap
+++ b/test/integration/cmds/organization/__snapshots__/export.test.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`organization export snapshots should print help message: help data is correct 1`] = `
+"Usage: contentful organization export
+
+Options:
+  -h, --help                Show help                                  [boolean]
+  --management-token, --mt  Contentful management API token             [string]
+  --organization-id, --oid  ID of Organization with source data
+                                                             [string] [required]
+  --header, -H              Pass an additional HTTP Header              [string]
+  --output-file, -o         Output file. It defaults to
+                            ./migrations/<timestamp>-<organization-id>.json
+                                                                        [string]
+
+See more at:
+https://github.com/contentful/contentful-cli/tree/master/docs/organization/expor
+t
+Copyright 2013 Contentful"
+`;

--- a/test/integration/cmds/organization/__snapshots__/export.test.ts.snap
+++ b/test/integration/cmds/organization/__snapshots__/export.test.ts.snap
@@ -14,6 +14,7 @@ Options:
                                                                         [string]
   --save-file               Save the export as a json file
                                                        [boolean] [default: true]
+  --silent, -S              suppress any log output   [boolean] [default: false]
 
 See more at:
 https://github.com/contentful/contentful-cli/tree/master/docs/organization/expor

--- a/test/integration/cmds/organization/__snapshots__/export.test.ts.snap
+++ b/test/integration/cmds/organization/__snapshots__/export.test.ts.snap
@@ -14,7 +14,7 @@ Options:
                                                                         [string]
   --save-file               Save the export as a json file
                                                        [boolean] [default: true]
-  --silent, -S              suppress any log output   [boolean] [default: false]
+  --silent, -S              Suppress any log output   [boolean] [default: false]
 
 See more at:
 https://github.com/contentful/contentful-cli/tree/master/docs/organization/expor

--- a/test/integration/cmds/organization/__snapshots__/export.test.ts.snap
+++ b/test/integration/cmds/organization/__snapshots__/export.test.ts.snap
@@ -12,6 +12,8 @@ Options:
   --output-file, -o         Output file. It defaults to
                             ./migrations/<timestamp>-<organization-id>.json
                                                                         [string]
+  --save-file               Save the export as a json file
+                                                       [boolean] [default: true]
 
 See more at:
 https://github.com/contentful/contentful-cli/tree/master/docs/organization/expor

--- a/test/integration/cmds/organization/export.test.ts
+++ b/test/integration/cmds/organization/export.test.ts
@@ -17,7 +17,7 @@ type Result = {
 
 const cmd = 'organization export'
 
-describe('organization export snapshots', () => {
+describe('organization export', () => {
   test('should print help message', done => {
     app()
       .run(`${cmd} --help`)

--- a/test/integration/cmds/organization/export.test.ts
+++ b/test/integration/cmds/organization/export.test.ts
@@ -18,17 +18,17 @@ type Result = {
 const cmd = 'organization export'
 
 describe('organization export snapshots', () => {
-  test('should print help message', done => {
-    app()
-      .run(`${cmd} --help`)
-      .code(0)
-      .expect(result => {
-        const text = result.stdout.trim()
-        const resultText = replaceCopyrightYear(text)
-        expect(resultText).toMatchSnapshot('help data is incorrect')
-      })
-      .end(done)
-  })
+  // test('should print help message', done => {
+  //   app()
+  //     .run(`${cmd} --help`)
+  //     .code(0)
+  //     .expect(result => {
+  //       const text = result.stdout.trim()
+  //       const resultText = replaceCopyrightYear(text)
+  //       expect(resultText).toMatchSnapshot('help data is incorrect')
+  //     })
+  //     .end(done)
+  // })
   it('should exit 1 when no args', done => {
     app()
       .run(`${cmd}`)

--- a/test/integration/cmds/organization/export.test.ts
+++ b/test/integration/cmds/organization/export.test.ts
@@ -1,6 +1,7 @@
 import nixt from 'nixt'
 import { join } from 'path'
 const bin = join(__dirname, './../../../../', 'bin')
+const { replaceCopyrightYear } = require('../../util')
 
 const organizationId = process.env.CLI_E2E_ORG_ID
 const org = process.env.CLI_E2E_ORG_ID
@@ -17,12 +18,13 @@ type Result = {
 const cmd = 'organization export'
 
 describe('organization export snapshots', () => {
-  it('shows the help properly', done => {
+  test('should print help message', done => {
     app()
       .run(`${cmd} --help`)
       .code(0)
-      .expect(({ stdout }: Result) => {
-        const resultText = stdout.trim()
+      .expect(result => {
+        const text = result.stdout.trim()
+        const resultText = replaceCopyrightYear(text)
         expect(resultText).toMatchSnapshot('help data is incorrect')
       })
       .end(done)

--- a/test/integration/cmds/organization/export.test.ts
+++ b/test/integration/cmds/organization/export.test.ts
@@ -68,4 +68,20 @@ describe('organization export snapshots', () => {
       })
       .end(done)
   })
+  it('should suppress any log output when silent is true', done => {
+    app()
+      .run(`${cmd} --organization-id ${organizationId} --silent=true`)
+      .code(0)
+      .expect(({ stdout }: Result) => {
+        const resultText = stdout.trim()
+
+        expect(resultText).not.toContain('Exporting Concepts')
+        expect(resultText).not.toContain('Exporting Concepts')
+        expect(resultText).not.toContain('Exporting Concept Schemes')
+        expect(resultText).not.toContain('Organization data exported to')
+        expect(resultText).not.toContain('concepts')
+        expect(resultText).not.toContain('conceptSchemes')
+      })
+      .end(done)
+  })
 })

--- a/test/integration/cmds/organization/export.test.ts
+++ b/test/integration/cmds/organization/export.test.ts
@@ -18,17 +18,17 @@ type Result = {
 const cmd = 'organization export'
 
 describe('organization export snapshots', () => {
-  // test('should print help message', done => {
-  //   app()
-  //     .run(`${cmd} --help`)
-  //     .code(0)
-  //     .expect(result => {
-  //       const text = result.stdout.trim()
-  //       const resultText = replaceCopyrightYear(text)
-  //       expect(resultText).toMatchSnapshot('help data is incorrect')
-  //     })
-  //     .end(done)
-  // })
+  test('should print help message', done => {
+    app()
+      .run(`${cmd} --help`)
+      .code(0)
+      .expect(result => {
+        const text = result.stdout.trim()
+        const resultText = replaceCopyrightYear(text)
+        expect(resultText).toMatchSnapshot('help data is correct')
+      })
+      .end(done)
+  })
   it('should exit 1 when no args', done => {
     app()
       .run(`${cmd}`)

--- a/test/integration/cmds/organization/export.test.ts
+++ b/test/integration/cmds/organization/export.test.ts
@@ -23,7 +23,6 @@ describe('organization export snapshots', () => {
       .code(0)
       .expect(({ stdout }: Result) => {
         const resultText = stdout.trim()
-
         expect(resultText).toMatchSnapshot('help data is incorrect')
       })
       .end(done)

--- a/test/integration/cmds/organization/export.test.ts
+++ b/test/integration/cmds/organization/export.test.ts
@@ -20,9 +20,10 @@ describe('organization export snapshots', () => {
   it('shows the help properly', done => {
     app()
       .run(`${cmd} --help`)
-      .code(1)
+      .code(0)
       .expect(({ stdout }: Result) => {
         const resultText = stdout.trim()
+
         expect(resultText).toMatchSnapshot('help data is incorrect')
       })
       .end(done)
@@ -33,6 +34,7 @@ describe('organization export snapshots', () => {
       .code(1)
       .expect(({ stderr }: Result) => {
         const resultText = stderr.trim()
+
         expect(resultText).toContain('Usage: contentful organization export')
       })
       .end(done)

--- a/test/integration/cmds/organization/export.test.ts
+++ b/test/integration/cmds/organization/export.test.ts
@@ -2,6 +2,9 @@ import nixt from 'nixt'
 import { join } from 'path'
 const bin = join(__dirname, './../../../../', 'bin')
 
+const organizationId = process.env.CLI_E2E_ORG_ID
+const org = process.env.CLI_E2E_ORG_ID
+
 const app = () => {
   return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
 }
@@ -13,7 +16,7 @@ type Result = {
 
 const cmd = 'organization export'
 
-describe.only('organization export snapshots', () => {
+describe('organization export snapshots', () => {
   it('shows the help properly', done => {
     app()
       .run(`${cmd} --help`)
@@ -24,27 +27,41 @@ describe.only('organization export snapshots', () => {
       })
       .end(done)
   })
-
   it('should exit 1 when no args', done => {
     app()
       .run(`${cmd}`)
       .code(1)
       .expect(({ stderr }: Result) => {
         const resultText = stderr.trim()
-        expect(resultText).toContain('Usage: organization export')
+        expect(resultText).toContain('Usage: contentful organization export')
       })
       .end(done)
   })
-
   it('should exit 1 when no organization id passed or in context', done => {
     app()
-      .run(`${cmd} --header 'Authorization`)
+      .run(`${cmd} --header 'Authorization'`)
       .code(1)
       .expect(({ stderr }: Result) => {
         const resultText = stderr.trim()
         expect(resultText).toContain(
-          'Error: You need to provide a organization id'
+          'Missing required argument: organization-id'
         )
+      })
+      .end(done)
+  })
+  it('should return concepts / concepts scheme', done => {
+    app()
+      .run(`${cmd} --organization-id ${organizationId}`)
+      .code(0)
+      .expect(({ stdout }: Result) => {
+        const resultText = stdout.trim()
+
+        expect(resultText).toContain('Exporting Concepts')
+        expect(resultText).toContain('Exporting Concepts')
+        expect(resultText).toContain('Exporting Concept Schemes')
+        expect(resultText).toContain('Organization data exported to')
+        expect(resultText).toContain('concepts')
+        expect(resultText).toContain('conceptSchemes')
       })
       .end(done)
   })

--- a/test/integration/cmds/organization/export.test.ts
+++ b/test/integration/cmds/organization/export.test.ts
@@ -54,7 +54,7 @@ describe('organization export snapshots', () => {
   })
   it('should return concepts / concepts scheme', done => {
     app()
-      .run(`${cmd} --organization-id ${organizationId}`)
+      .run(`${cmd} --organization-id ${organizationId} --save-file=false`)
       .code(0)
       .expect(({ stdout }: Result) => {
         const resultText = stdout.trim()

--- a/test/integration/cmds/organization/export.test.ts
+++ b/test/integration/cmds/organization/export.test.ts
@@ -1,0 +1,51 @@
+import nixt from 'nixt'
+import { join } from 'path'
+const bin = join(__dirname, './../../../../', 'bin')
+
+const app = () => {
+  return nixt({ newlines: true }).cwd(bin).base('./contentful.js ').clone()
+}
+
+type Result = {
+  stderr: string
+  stdout: string
+}
+
+const cmd = 'organization export'
+
+describe.only('organization export snapshots', () => {
+  it('shows the help properly', done => {
+    app()
+      .run(`${cmd} --help`)
+      .code(0)
+      .expect(({ stdout }: Result) => {
+        const resultText = stdout.trim()
+        expect(resultText).toMatchSnapshot('help data is incorrect')
+      })
+      .end(done)
+  })
+
+  it('should exit 1 when no args', done => {
+    app()
+      .run(`${cmd}`)
+      .code(1)
+      .expect(({ stderr }: Result) => {
+        const resultText = stderr.trim()
+        expect(resultText).toContain('Usage: organization export')
+      })
+      .end(done)
+  })
+
+  it('should exit 1 when no organization id passed or in context', done => {
+    app()
+      .run(`${cmd} --header 'Authorization`)
+      .code(1)
+      .expect(({ stderr }: Result) => {
+        const resultText = stderr.trim()
+        expect(resultText).toContain(
+          'Error: You need to provide a organization id'
+        )
+      })
+      .end(done)
+  })
+})

--- a/test/integration/cmds/organization/export.test.ts
+++ b/test/integration/cmds/organization/export.test.ts
@@ -20,7 +20,7 @@ describe('organization export snapshots', () => {
   it('shows the help properly', done => {
     app()
       .run(`${cmd} --help`)
-      .code(0)
+      .code(1)
       .expect(({ stdout }: Result) => {
         const resultText = stdout.trim()
         expect(resultText).toMatchSnapshot('help data is incorrect')

--- a/test/unit/cmds/organization_cmds/export.test.ts
+++ b/test/unit/cmds/organization_cmds/export.test.ts
@@ -1,0 +1,99 @@
+import { CollectionProp, ConceptProps } from 'contentful-management'
+import organizationExport from '../../../../lib/cmds/organization_cmds/export'
+import { createPlainClient } from '../../../../lib/utils/contentful-clients'
+
+jest.mock('../../../../lib/context')
+jest.mock('../../../../lib/utils/contentful-clients')
+jest.mock('../../../../lib/utils/log')
+
+const createTaxonomyConceptMock = (id: string): ConceptProps => ({
+  sys: {
+    id,
+    type: 'TaxonomyConcept',
+    createdAt: '2021-01-01T00:00:00.000Z',
+    createdBy: {
+      sys: {
+        type: 'Link',
+        linkType: 'User',
+        id: 'userId'
+      }
+    },
+    updatedBy: {
+      sys: {
+        type: 'Link',
+        linkType: 'User',
+        id: 'userId'
+      }
+    },
+    updatedAt: '2021-01-01T00:00:00.000Z',
+    version: 1
+  },
+  prefLabel: {
+    en: 'prefLabel'
+  },
+  altLabels: {
+    en: ['altLabel']
+  },
+  definition: {
+    en: 'definition'
+  },
+  note: {
+    en: 'notes'
+  },
+  scopeNote: {
+    en: 'scopeNote'
+  },
+  editorialNote: {
+    en: 'editorialNote'
+  },
+  historyNote: {
+    en: 'historyNote'
+  },
+  hiddenLabels: {
+    en: ['hiddenLabel']
+  },
+  uri: 'uri' + id,
+  broader: [],
+  related: [],
+  example: {
+    en: 'example'
+  },
+  notations: ['notation']
+})
+
+const conceptsData = {
+  sys: {
+    type: 'Array'
+  },
+  items: [createTaxonomyConceptMock('1'), createTaxonomyConceptMock('2')]
+}
+
+const fakeClient = {
+  concept: {
+    getMany: jest.fn().mockResolvedValue(conceptsData)
+  },
+  conceptScheme: {
+    getMany: jest.fn().mockResolvedValue({ items: [] })
+  }
+}
+
+const mockCreatePlainClient = (
+  createPlainClient as unknown as jest.Mock
+).mockResolvedValue(fakeClient)
+
+afterEach(() => {
+  mockCreatePlainClient.mockClear()
+})
+
+test.only('initializes client', async () => {
+  await organizationExport({
+    context: {
+      managementToken: 'managementToken'
+    },
+    organizationId: 'mockedOrganizationId'
+  })
+
+  expect(mockCreatePlainClient).toHaveBeenCalledTimes(1)
+  expect(fakeClient.concept.getMany).toHaveBeenCalledTimes(1)
+  expect(fakeClient.conceptScheme.getMany).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
Adds a new command to export organization entities. For now this includes only taxonomy data.

As a user, I should be able to run contentful organization export --organization-id <organization-id> and get the export of my taxonomy like:

`{ "taxonomy": { "concepts": [], "conceptSchemes": [] } }`

