### PR TITLE
fix: change description for output file in org export

### DIFF
--- a/lib/cmds/organization_cmds/export.ts
+++ b/lib/cmds/organization_cmds/export.ts
@@ -37,7 +37,7 @@ module.exports.builder = (yargs: Argv) => {
       alias: 'o',
       type: 'string',
       describe:
-        'Output file. It defaults to ./migrations/<timestamp>-<organization-id>.json'
+        'Output file. It defaults to ./data/<timestamp>-<organization-id>.json'
     })
     .option('save-file', {
       describe: 'Save the export as a json file',

--- a/test/integration/cmds/organization/__snapshots__/export.test.ts.snap
+++ b/test/integration/cmds/organization/__snapshots__/export.test.ts.snap
@@ -10,8 +10,7 @@ Options:
                                                              [string] [required]
   --header, -H              Pass an additional HTTP Header              [string]
   --output-file, -o         Output file. It defaults to
-                            ./migrations/<timestamp>-<organization-id>.json
-                                                                        [string]
+                            ./data/<timestamp>-<organization-id>.json   [string]
   --save-file               Save the export as a json file
                                                        [boolean] [default: true]
   --silent, -S              Suppress any log output   [boolean] [default: false]


### PR DESCRIPTION
The description says the output directory is `migrations` but later in the code it's `data`

https://github.com/contentful/contentful-cli/pull/2794/files#diff-aac00e876afd4ffa5bd4687076602b890ad5a0d68ea0f30b681052d67ca2a5fcR90