### PR TITLE
fix: allow host-delivery config to be passed to export command [EXT-5986]

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ When multiple proxy configurations exists, precedence is taken in this form:
 You can override the host configuration in your `.contentfulrc.json` via:
 
 ```sh
-contentful config add --host api.eu.contentful.com
+contentful config add --host api.eu.contentful.com --host-delivery cdn.eu.contentful.com
 ```
 
-Then any subsequent command will use the EU host. E.g. `contentful login` will log you in to your EU Contentful instance.
+Then any subsequent command will use the EU hosts. E.g. `contentful login` will log you in to your EU Contentful instance.
 
 ## :rescue_worker_helmet: Troubleshooting
 

--- a/lib/cmds/space_cmds/export.js
+++ b/lib/cmds/space_cmds/export.js
@@ -90,6 +90,10 @@ module.exports.builder = function (yargs) {
       describe: 'Management API host',
       type: 'string'
     })
+    .option('host-delivery', {
+      describe: 'Delivery API host',
+      type: 'string',
+    })
     .option('proxy', {
       describe:
         'Proxy configuration in HTTP auth format: [http|https]://host:port or [http|https]://user:password@host:port',


### PR DESCRIPTION
> [!IMPORTANT]  
> Must be merged after https://github.com/contentful/contentful-export/pull/1921 is merged and contentful-export is bumped in this repo


## Summary

This changeset allows the `contentful space export` command to use a `--host-delivery` flag to point at cdn.eu.contentful.com

