### PR TITLE
fix: bump contentful-export to include asset download fix [ZEND-5790]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "command-exists": "^1.2.7",
         "contentful-batch-libs": "^10.1.1",
         "contentful-collection": "^0.0.4",
-        "contentful-export": "7.21.1",
+        "contentful-export": "7.21.12",
         "contentful-import": "9.4.75",
         "contentful-management": "^11.39.0",
         "contentful-migration": "^4.21.0",
@@ -6137,10 +6137,9 @@
       "integrity": "sha512-AvrnEeMTJtRy9SeuHrLbk/bntLwEE9FrhPfFcBp08md0Nz3N7a2+SmZgF5ZTyBRVc9pHjg+Fg6+O5c9q7Tj5HQ=="
     },
     "node_modules/contentful-export": {
-      "version": "7.21.1",
-      "resolved": "https://registry.npmjs.org/contentful-export/-/contentful-export-7.21.1.tgz",
-      "integrity": "sha512-/b+QvrzAWTqZYlWT76WHIMBixXQ3MdInLUZglOA9i3qWiya6NXou6Vn3sDGsZ8UXaLukDOAxuG+e89vwt3nB/w==",
-      "license": "MIT",
+      "version": "7.21.12",
+      "resolved": "https://registry.npmjs.org/contentful-export/-/contentful-export-7.21.12.tgz",
+      "integrity": "sha512-4wTeBE0iv6/Vf/Gzd7kchHxC3ONtuPFrA7dLHbAKb8wMFcxSR0Xk1qUPCIFzjVPKeVDjOdf0KHsRPgXQUNkdeg==",
       "dependencies": {
         "axios": "^1.7.8",
         "bfj": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "command-exists": "^1.2.7",
     "contentful-batch-libs": "^10.1.1",
     "contentful-collection": "^0.0.4",
-    "contentful-export": "7.21.1",
+    "contentful-export": "7.21.12",
     "contentful-import": "9.4.75",
     "contentful-management": "^11.39.0",
     "contentful-migration": "^4.21.0",


### PR DESCRIPTION
manual bump to ensure https://github.com/contentful/contentful-export/pull/1953 is released