### PR TITLE
fix: allow --skip-content-updates and --skip-asset-updates import flags [EXT-6233]

### DIFF
--- a/lib/cmds/space_cmds/import.ts
+++ b/lib/cmds/space_cmds/import.ts
@@ -54,6 +54,16 @@ export const builder = (yargs: Argv) => {
       type: 'boolean',
       default: false
     })
+    .option('skip-content-updates', {
+      describe: 'Skips updating existing content, only creates new entries.',
+      type: 'boolean',
+      default: false
+    })
+    .option('skip-asset-updates', {
+      describe: 'Skips updating existing assets, only creates new assets.',
+      type: 'boolean',
+      default: false
+    })
     .option('update', {
       describe: 'Update entries if they already exist',
       type: 'boolean',

--- a/test/integration/cmds/space/__snapshots__/import.test.js.snap
+++ b/test/integration/cmds/space/__snapshots__/import.test.js.snap
@@ -16,6 +16,10 @@ Options:
   --skip-locales             Skip importing locales   [boolean] [default: false]
   --skip-content-publishing  Skips content publishing. Creates content but does
                              not publish it           [boolean] [default: false]
+  --skip-content-updates     Skips updating existing content, only creates new
+                             entries.                 [boolean] [default: false]
+  --skip-asset-updates       Skips updating existing assets, only creates new
+                             assets.                  [boolean] [default: false]
   --error-log-file           Full path to the error log file            [string]
   --host                     Management API host                        [string]
   --proxy                    Proxy configuration in HTTP auth format:
@@ -49,6 +53,10 @@ Options:
   --skip-locales             Skip importing locales   [boolean] [default: false]
   --skip-content-publishing  Skips content publishing. Creates content but does
                              not publish it           [boolean] [default: false]
+  --skip-content-updates     Skips updating existing content, only creates new
+                             entries.                 [boolean] [default: false]
+  --skip-asset-updates       Skips updating existing assets, only creates new
+                             assets.                  [boolean] [default: false]
   --error-log-file           Full path to the error log file            [string]
   --host                     Management API host                        [string]
   --proxy                    Proxy configuration in HTTP auth format:

--- a/test/unit/cmds/space_cmds/import.test.ts
+++ b/test/unit/cmds/space_cmds/import.test.ts
@@ -23,6 +23,8 @@ test('it should pass all args to contentful-import', async () => {
     skipLocales: false,
     host: 'api.contentful.com',
     skipContentPublishing: false,
+    skipContentUpdates: true,
+    skipAssetUpdates: true,
     managementApplication: `contentful.cli/${version}`,
     managementFeature: 'space-import'
   }
@@ -33,7 +35,9 @@ test('it should pass all args to contentful-import', async () => {
     spaceId: 'spaceId',
     environmentId: undefined,
     host: undefined,
-    headers: {}
+    headers: {},
+    skipContentUpdates: true,
+    skipAssetUpdates: true
   }
   expect(contentfulImport.mock.calls[0][0]).toEqual(result)
   expect(contentfulImport).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

The contentful-import library supports the [--skipContentUpdates](https://github.com/contentful/contentful-import?tab=readme-ov-file#skipcontentupdates-boolean-default-false) and [--skipAssetUpdates](https://github.com/contentful/contentful-import?tab=readme-ov-file#skipassetupdates-boolean-default-false) flags. This change allows these flags to be propagated from the CLI to the import library
