### PR TITLE
chore: update docs with embargoed asset import/export info [DX-63]

### DIFF
--- a/docs/space/export/README.md
+++ b/docs/space/export/README.md
@@ -45,7 +45,7 @@ Options:
   --proxy                   Proxy configuration in HTTP auth format:
                             [http|https]://host:port or
                             [http|https]://user:password@host:port        [string]
-  --raw-proxy               Pass proxy config to Axios instead of creating a 
+  --raw-proxy               Pass proxy config to Axios instead of creating a
                             custom httpsAgent.                           [boolean]
   --error-log-file          Full path to the error log file               [string]
   --query-entries           Exports only entries that matches these queries[array]
@@ -84,3 +84,4 @@ contentful space export
 - This tool currently does **not** support the export of space memberships.
 - Exported webhooks with credentials will be exported as normal webhooks. Credentials should be added manually afterwards.
 - UI extensions will not be exported
+- If a space is configured to use the [embargoed assets feature](https://www.contentful.com/help/media/embargoed-assets/), certain options will need to be set to use the space export/import tooling. When exporting content, the `downloadAssets` option must be set to `true`. This will download the asset files to your local machine. Then, when importing content, the `uploadAssets` option must be set to `true` and the `assetsDirectory` must be set to the directory that contains all of the exported asset folders.

--- a/docs/space/import/README.md
+++ b/docs/space/import/README.md
@@ -57,3 +57,4 @@ contentful space import \
 - This tool is expecting the target space to have the same default locale as your previously exported space.
 - Imported webhooks with credentials will be imported as normal webhooks. Credentials should be added manually afterwards.
 - If you have custom UI extensions, you need to reinstall them manually in the new space. Check this [link](https://www.contentful.com/blog/2016/07/06/ui-extensions-sdk/) on how to install them
+- If a space is configured to use the [embargoed assets feature](https://www.contentful.com/help/media/embargoed-assets/), certain options will need to be set to use the space export/import tooling. When exporting content, the `downloadAssets` option must be set to `true`. This will download the asset files to your local machine. Then, when importing content, the `uploadAssets` option must be set to `true` and the `assetsDirectory` must be set to the directory that contains all of the exported asset folders.


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

It was unclear how a user should use the `contentful space export` and `contentful space import` commands if their space has embargoed assets. This PR adds instructions in the docs for these commands

## Description

Add instructions in the appropriate docs files for how to use export and import with embargoed assets. 

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

## Screenshots (if appropriate):
