### PR TITLE
fix: handle undefined values in migration generation [ZEND-6547]

### DIFF
--- a/lib/cmds/space_cmds/generate_cmds/migration.js
+++ b/lib/cmds/space_cmds/generate_cmds/migration.js
@@ -246,6 +246,10 @@ const changeFieldControl = function (
   widgetId,
   settings
 ) {
+  if (!widgetNamespace || !widgetId) {
+    return null
+  }
+
   const ctVariable = ctVariableEscape(ctId)
   settings = settings || {}
 
@@ -299,18 +303,22 @@ const generateContentTypeMigration = async function (environment, contentType) {
         return control.fieldId === field.id
       })
 
+      if (!control) {
+        return null
+      }
+
       const { widgetId, settings, widgetNamespace = 'builtin' } = control
 
-      return b.expressionStatement(
-        changeFieldControl(
-          contentType.sys.id,
-          field.id,
-          widgetNamespace,
-          widgetId,
-          settings
-        )
+      const changeFieldControlCall = changeFieldControl(
+        contentType.sys.id,
+        field.id,
+        widgetNamespace,
+        widgetId,
+        settings
       )
-    })
+
+      return changeFieldControlCall ? b.expressionStatement(changeFieldControlCall) : null
+    }).filter(creator => creator !== null)
   } catch (err) {
     if (err.name === 'NotFound') {
       log('Skipping editor interfaces. Content type has no fields.')

--- a/lib/cmds/space_cmds/generate_cmds/migration.js
+++ b/lib/cmds/space_cmds/generate_cmds/migration.js
@@ -189,7 +189,7 @@ const createContentType = function (ct) {
     ['name', name],
     ['description', description],
     ['displayField', displayField]
-  ].filter(([, value]) => value !== null)
+  ].filter(([, value]) => value !== null && value !== undefined)
 
   const variableName = ctVariableEscape(id)
 
@@ -218,7 +218,7 @@ const createField = function (ctId, field) {
 
   const chain = Object.keys(_.omit(field, 'id')).map(key => {
     return [key, field[key]]
-  })
+  }).filter(([, value]) => value !== null && value !== undefined)
 
   return createCallChain(
     b.callExpression(
@@ -242,9 +242,11 @@ const changeFieldControl = function (
   settings = settings || {}
 
   const settingsExpression = b.objectExpression(
-    _.map(settings, (v, k) => {
-      return b.property('init', b.identifier(k), b.literal(v))
-    })
+    Object.entries(settings)
+      .filter(([k, v]) => v !== null && v !== undefined)
+      .map(([k, v]) => {
+        return b.property('init', b.identifier(k), b.literal(v))
+      })
   )
 
   return b.callExpression(

--- a/lib/cmds/space_cmds/generate_cmds/migration.js
+++ b/lib/cmds/space_cmds/generate_cmds/migration.js
@@ -151,6 +151,12 @@ const ctVariableEscape = function (ctId) {
 
 module.exports.ctVariableEscape = ctVariableEscape
 
+const filterNullAndUndefined = function (entries) {
+  return entries.filter(([, value]) => value !== null && value !== undefined)
+}
+
+module.exports.filterNullAndUndefined = filterNullAndUndefined
+
 const wrapMigrationWithBase = function (blockStatement) {
   const migration = b.program([
     b.expressionStatement(
@@ -185,11 +191,11 @@ const createCallChain = function (base, chain) {
 const createContentType = function (ct) {
   const id = ct.sys.id
   const { name, description, displayField } = ct
-  const chain = [
+  const chain = filterNullAndUndefined([
     ['name', name],
     ['description', description],
     ['displayField', displayField]
-  ].filter(([, value]) => value !== null && value !== undefined)
+  ])
 
   const variableName = ctVariableEscape(id)
 
@@ -216,9 +222,11 @@ const createField = function (ctId, field) {
   const fieldId = field.id
   const ctVariable = ctVariableEscape(ctId)
 
-  const chain = Object.keys(_.omit(field, 'id')).map(key => {
-    return [key, field[key]]
-  }).filter(([, value]) => value !== null && value !== undefined)
+  const chain = filterNullAndUndefined(
+    Object.keys(_.omit(field, 'id')).map(key => {
+      return [key, field[key]]
+    })
+  )
 
   return createCallChain(
     b.callExpression(
@@ -242,8 +250,7 @@ const changeFieldControl = function (
   settings = settings || {}
 
   const settingsExpression = b.objectExpression(
-    Object.entries(settings)
-      .filter(([k, v]) => v !== null && v !== undefined)
+    filterNullAndUndefined(Object.entries(settings))
       .map(([k, v]) => {
         return b.property('init', b.identifier(k), b.literal(v))
       })

--- a/test/unit/cmds/space_cmds/generate_cmds/migration.test.js
+++ b/test/unit/cmds/space_cmds/generate_cmds/migration.test.js
@@ -40,6 +40,25 @@ const simpleContentType = {
   ]
 }
 
+const contentTypeWithUndefined = {
+  sys: {
+    id: 'bar'
+  },
+  name: 'Bar',
+  description: undefined,
+  displayField: undefined,
+  fields: [
+    {
+      id: 'title',
+      name: 'Title',
+      type: 'Symbol',
+      required: undefined,
+      localized: undefined,
+      disabled: false
+    }
+  ]
+}
+
 const editorInterface = {
   controls: [
     {
@@ -48,6 +67,21 @@ const editorInterface = {
       widgetNamespace: 'builtin',
       settings: {
         helpText: 'the name'
+      }
+    }
+  ]
+}
+
+const editorInterfaceWithUndefined = {
+  controls: [
+    {
+      fieldId: 'title',
+      widgetId: 'singleLine',
+      widgetNamespace: 'builtin',
+      settings: {
+        helpText: undefined,
+        placeholder: 'Enter title',
+        showLinkEntityAction: undefined
       }
     }
   ]
@@ -165,6 +199,58 @@ test('it creates the editor interface', async () => {
   const expected = `module.exports = function(migration) {
     foo.changeFieldControl("name", "builtin", "singleLine", {
         helpText: "the name"
+    });
+};`
+
+  expect(recast.prettyPrint(wrapMigrationWithBase(programStub)).code).toBe(
+    expected
+  )
+})
+
+test('it handles undefined values in content type', async () => {
+  const programStub = b.blockStatement([createContentType(contentTypeWithUndefined)])
+
+  const expected = `module.exports = function(migration) {
+    const bar = migration.createContentType("bar").name("Bar");
+};`
+
+  expect(recast.prettyPrint(wrapMigrationWithBase(programStub)).code).toBe(
+    expected
+  )
+})
+
+test('it handles undefined values in field properties', async () => {
+  const programStub = b.blockStatement([
+    b.expressionStatement(
+      createField(contentTypeWithUndefined.sys.id, contentTypeWithUndefined.fields[0])
+    )
+  ])
+
+  const expected = `module.exports = function(migration) {
+    bar.createField("title").name("Title").type("Symbol").disabled(false);
+};`
+
+  expect(recast.prettyPrint(wrapMigrationWithBase(programStub)).code).toBe(
+    expected
+  )
+})
+
+test('it handles undefined values in editor interface settings', async () => {
+  const programStub = b.blockStatement([
+    b.expressionStatement(
+      changeFieldControl(
+        'bar',
+        editorInterfaceWithUndefined.controls[0].fieldId,
+        editorInterfaceWithUndefined.controls[0].widgetNamespace,
+        editorInterfaceWithUndefined.controls[0].widgetId,
+        editorInterfaceWithUndefined.controls[0].settings
+      )
+    )
+  ])
+
+  const expected = `module.exports = function(migration) {
+    bar.changeFieldControl("title", "builtin", "singleLine", {
+        placeholder: "Enter title"
     });
 };`
 

--- a/test/unit/cmds/space_cmds/generate_cmds/migration.test.js
+++ b/test/unit/cmds/space_cmds/generate_cmds/migration.test.js
@@ -87,6 +87,23 @@ const editorInterfaceWithUndefined = {
   ]
 }
 
+const editorInterfaceWithMissingProperties = {
+  controls: [
+    {
+      fieldId: 'title',
+      widgetId: 'singleLine',
+      widgetNamespace: 'builtin',
+      settings: {
+        helpText: 'Valid title'
+      }
+    },
+    {
+      fieldId: 'description'
+      // Missing widgetId and widgetNamespace
+    }
+  ]
+}
+
 const EditorInterfaceNotFoundErrorMock = function () {
   this.name = 'NotFound'
 }
@@ -257,6 +274,27 @@ test('it handles undefined values in editor interface settings', async () => {
   expect(recast.prettyPrint(wrapMigrationWithBase(programStub)).code).toBe(
     expected
   )
+})
+
+test('it skips changeFieldControl when required parameters are undefined', async () => {
+  const validControl = changeFieldControl(
+    'bar',
+    editorInterfaceWithMissingProperties.controls[0].fieldId,
+    editorInterfaceWithMissingProperties.controls[0].widgetNamespace,
+    editorInterfaceWithMissingProperties.controls[0].widgetId,
+    editorInterfaceWithMissingProperties.controls[0].settings
+  )
+
+  const invalidControl = changeFieldControl(
+    'bar',
+    editorInterfaceWithMissingProperties.controls[1].fieldId,
+    editorInterfaceWithMissingProperties.controls[1].widgetNamespace,
+    editorInterfaceWithMissingProperties.controls[1].widgetId,
+    editorInterfaceWithMissingProperties.controls[1].settings
+  )
+
+  expect(validControl).not.toBeNull()
+  expect(invalidControl).toBeNull()
 })
 
 test('it creates the full migration script', async () => {


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

The `contentful space generate migration` command was failing with the error:
> Error: undefined does not match field "value": string | boolean | null | number | RegExp | BigInt of type Literal

This error caused **all `changeFieldControl` calls to be missing** from generated migration files. Customers reported that previously working migrations were no longer generating complete output, with essential editor interface configurations being omitted entirely.

**Example of missing output:**
```javascript
brand.changeFieldControl("name", "builtin", "singleLine", {});
brand.changeFieldControl("foo", "builtin", "singleLine", {});
brand.changeFieldControl("bar", "builtin", "dropdown", {});
// ... etc
```

### Root Cause
The error occurred when editor interface settings contained `undefined` values, which were being passed to the `b.literal()` function that only accepts specific types (string, boolean, null, number, RegExp, BigInt). When this error was thrown during the `changeFieldControl` generation loop, it caused the entire editor interface section to be skipped.

## Description

### Solution
Added filtering to exclude `undefined` and `null` values in three key areas:

1. **Content Type Creation**: Filter out `undefined` values from content type properties (name, description, displayField)
2. **Field Creation**: Filter out `undefined` and `null` values from field properties before AST generation  
3. **Editor Interface Settings**: Filter out `undefined` and `null` values from widget settings before passing to `b.literal()`

### Impact
- **Fixes migration generation errors** when content models contain `undefined` values
- **Restores missing `changeFieldControl` calls** in generated migrations
- **Maintains backward compatibility** with existing functionality
- **No breaking changes** to the migration file format
- Generated migrations now include complete editor interface configurations

### Testing
- Added comprehensive test cases covering all three scenarios with `undefined` values
- Verified that `changeFieldControl` calls are generated with filtered settings objects
- Confirmed existing functionality remains unchanged
- All existing tests continue to pass
