### PR TITLE
fix: handle merge app and action ids for eu host [DX-353]

### DIFF
--- a/lib/utils/app-actions-config.ts
+++ b/lib/utils/app-actions-config.ts
@@ -1,12 +1,16 @@
 type AppActionTypes = 'create-changeset' | 'export-changeset'
 
-export type Host = 'api.flinkly.com' | 'api.contentful.com'
+export type Host =
+  | 'api.flinkly.com'
+  | 'api.contentful.com'
+  | 'api.eu.contentful.com'
 
 const AppDefinitionIds: {
   [host in Host]: string
 } = {
   'api.contentful.com': 'cQeaauOu1yUCYVhQ00atE',
-  'api.flinkly.com': '7tBJPpcwK1E1KqlxlMiKw5'
+  'api.flinkly.com': '7tBJPpcwK1E1KqlxlMiKw5',
+  'api.eu.contentful.com': 'cQeaauOu1yUCYVhQ00atE'
 }
 
 const ActionIds: {
@@ -19,6 +23,10 @@ const ActionIds: {
     'export-changeset': '5saqHxAG2N0xHaZYXEe5dO'
   },
   'api.contentful.com': {
+    'create-changeset': '3yquPqLswfwwbY7taePuYp',
+    'export-changeset': '2z5CsfaFfA26RrLSXPcQtS'
+  },
+  'api.eu.contentful.com': {
     'create-changeset': '3yquPqLswfwwbY7taePuYp',
     'export-changeset': '2z5CsfaFfA26RrLSXPcQtS'
   }
@@ -36,5 +44,5 @@ export const getAppActionId = (action: AppActionTypes, host?: Host) => {
   if (!host) {
     host = 'api.contentful.com'
   }
-  return ActionIds[host as Host][action as AppActionTypes]
+  return ActionIds[host as Host]?.[action as AppActionTypes]
 }

--- a/test/unit/utils/app-actions-config.test.js
+++ b/test/unit/utils/app-actions-config.test.js
@@ -1,0 +1,95 @@
+import {
+  getAppDefinitionId,
+  getAppActionId
+} from '../../../lib/utils/app-actions-config'
+
+describe('app-actions-config', () => {
+  describe('getAppDefinitionId', () => {
+    it('returns correct app definition ID for api.contentful.com', () => {
+      const result = getAppDefinitionId('api.contentful.com')
+      expect(result).toBe('cQeaauOu1yUCYVhQ00atE')
+    })
+
+    it('returns correct app definition ID for api.eu.contentful.com', () => {
+      const result = getAppDefinitionId('api.eu.contentful.com')
+      expect(result).toBe('cQeaauOu1yUCYVhQ00atE')
+    })
+
+    it('returns correct app definition ID for api.flinkly.com', () => {
+      const result = getAppDefinitionId('api.flinkly.com')
+      expect(result).toBe('7tBJPpcwK1E1KqlxlMiKw5')
+    })
+
+    it('defaults to api.contentful.com when no host is provided', () => {
+      const result = getAppDefinitionId()
+      expect(result).toBe('cQeaauOu1yUCYVhQ00atE')
+    })
+
+    it('returns undefined app definition ID when invalid host is provided', () => {
+      const result = getAppDefinitionId('invalid-host')
+      expect(result).toBe(undefined)
+    })
+  })
+
+  describe('getAppActionId', () => {
+    describe('create-changeset action', () => {
+      it('returns correct action ID for api.contentful.com', () => {
+        const result = getAppActionId('create-changeset', 'api.contentful.com')
+        expect(result).toBe('3yquPqLswfwwbY7taePuYp')
+      })
+
+      it('returns correct action ID for api.eu.contentful.com', () => {
+        const result = getAppActionId(
+          'create-changeset',
+          'api.eu.contentful.com'
+        )
+        expect(result).toBe('3yquPqLswfwwbY7taePuYp')
+      })
+
+      it('returns correct action ID for api.flinkly.com', () => {
+        const result = getAppActionId('create-changeset', 'api.flinkly.com')
+        expect(result).toBe('4gwoIghhNwPmt8ISGkjOu1')
+      })
+
+      it('defaults to api.contentful.com when no host is provided', () => {
+        const result = getAppActionId('create-changeset')
+        expect(result).toBe('3yquPqLswfwwbY7taePuYp')
+      })
+
+      it('returns undefined app action ID when invalid host is provided', () => {
+        const result = getAppActionId('create-changeset', 'invalid-host')
+        expect(result).toBe(undefined)
+      })
+    })
+
+    describe('export-changeset action', () => {
+      it('returns correct action ID for api.contentful.com', () => {
+        const result = getAppActionId('export-changeset', 'api.contentful.com')
+        expect(result).toBe('2z5CsfaFfA26RrLSXPcQtS')
+      })
+
+      it('returns correct action ID for api.eu.contentful.com', () => {
+        const result = getAppActionId(
+          'export-changeset',
+          'api.eu.contentful.com'
+        )
+        expect(result).toBe('2z5CsfaFfA26RrLSXPcQtS')
+      })
+
+      it('returns correct action ID for api.flinkly.com', () => {
+        const result = getAppActionId('export-changeset', 'api.flinkly.com')
+        expect(result).toBe('5saqHxAG2N0xHaZYXEe5dO')
+      })
+
+      it('defaults to api.contentful.com when no host is provided', () => {
+        const result = getAppActionId('export-changeset')
+        expect(result).toBe('2z5CsfaFfA26RrLSXPcQtS')
+      })
+
+      it('returns undefined app action ID when invalid host is provided', () => {
+        const result = getAppActionId('export-changeset', 'invalid-host')
+        expect(result).toBe(undefined)
+      })
+    })
+  })
+})


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

When using the merge commands for an EU space when the app is not installed, the CLI errors.
                                
## Description

This PR adds handling for when the CLI config host is set to `api.eu.contentful.com` to ensure that the Merge app and action ids are passed correctly. Unit tests were also added to confirm expected behavior for the different host values.

## Motivation and Context

Fixes this problem:
```
❯ contentful merge export --te master --se dev 

🌐 Final CMA host: api.eu.contentful.com
The Merge app is not installed in any of the environments. Environment ids: dev, master
? Do you want to install the Merge app in both environments? Yes
🚨  Error: The resource could not be found.

{
 "status": 404, 
 "statusText": "Not Found",
 "message": "The resource could not be found.",
 "details": "AppDefinition does not exist.",
 "request": {
   "url": "/spaces/my-space/environments/dev/app_installations/undefined"
.....
  } 
```

Fixed terminal output:
```
 ❯ contentful merge export --te master --se dev

🌐 Final CMA host: api.eu.contentful.com
The Merge app is not installed in the environment with id: dev
? Do you want to install the Merge app in the environment with id: dev Yes
  ✔ Compute differences
  ✔ Create migration
✅ Migration exported to path/to/local/file.
```

