### PR TITLE
build(deps): bump contentful-export from 7.21.44 to 7.21.78 [DX-376]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "command-exists": "^1.2.7",
         "contentful-batch-libs": "^10.1.1",
         "contentful-collection": "^0.0.4",
-        "contentful-export": "7.21.44",
+        "contentful-export": "^7.21.78",
         "contentful-import": "9.4.99",
         "contentful-management": "^11.39.0",
         "contentful-migration": "^4.21.0",
@@ -6155,10 +6155,9 @@
       "integrity": "sha512-AvrnEeMTJtRy9SeuHrLbk/bntLwEE9FrhPfFcBp08md0Nz3N7a2+SmZgF5ZTyBRVc9pHjg+Fg6+O5c9q7Tj5HQ=="
     },
     "node_modules/contentful-export": {
-      "version": "7.21.44",
-      "resolved": "https://registry.npmjs.org/contentful-export/-/contentful-export-7.21.44.tgz",
-      "integrity": "sha512-Ue1cTRTLwK6LXNh7iarl/7tk5nyCTVRz2TML5xE44+AKm5c04zpAuYCurh+KT0Tk+CWEXcVqPLI/8dmwr0HBdA==",
-      "license": "MIT",
+      "version": "7.21.78",
+      "resolved": "https://registry.npmjs.org/contentful-export/-/contentful-export-7.21.78.tgz",
+      "integrity": "sha512-+XZ2F2d+7gC8NCMrnIGhuVVaLfK4+HFg3S77nSGeAPAMt5VWF3b4IuHcTzPbFUQoQXFPjrga5sJqJUhNNmdqrQ==",
       "dependencies": {
         "axios": "^1.8.4",
         "bfj": "^8.0.0",
@@ -6175,7 +6174,7 @@
         "listr-verbose-renderer": "^0.6.0",
         "lodash.startcase": "^4.4.0",
         "mkdirp": "^2.0.0",
-        "yargs": "^17.1.1"
+        "yargs": "^18.0.0"
       },
       "bin": {
         "contentful-export": "bin/contentful-export"
@@ -6184,17 +6183,39 @@
         "node": ">=18"
       }
     },
-    "node_modules/contentful-export/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
+    "node_modules/contentful-export/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/contentful-export/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/contentful-export/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/contentful-export/node_modules/contentful-batch-libs": {
@@ -6227,6 +6248,11 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
+    "node_modules/contentful-export/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg=="
+    },
     "node_modules/contentful-export/node_modules/mkdirp": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
@@ -6241,6 +6267,52 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/contentful-export/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/contentful-export/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/contentful-export/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/contentful-export/node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -6250,28 +6322,27 @@
       }
     },
     "node_modules/contentful-export/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
       "dependencies": {
-        "cliui": "^8.0.1",
+        "cliui": "^9.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
+        "string-width": "^7.2.0",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
+        "yargs-parser": "^22.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/contentful-export/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "engines": {
-        "node": ">=12"
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/contentful-import": {
@@ -9078,7 +9149,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
       "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
-      "dev": true,
       "engines": {
         "node": ">=18"
       },

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "command-exists": "^1.2.7",
     "contentful-batch-libs": "^10.1.1",
     "contentful-collection": "^0.0.4",
-    "contentful-export": "7.21.44",
+    "contentful-export": "^7.21.78",
     "contentful-import": "9.4.99",
     "contentful-management": "^11.39.0",
     "contentful-migration": "^4.21.0",


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

JIRA: [DX-376](https://github.com/contentful/contentful-cli/pull/3088)

Bump contentful-export dependency up to `7.21.78` for url pathname fix. https://github.com/contentful/contentful-export/releases/tag/v7.21.78

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

- [ ] Implemented feature
- [ ] Feature with pending implementation

## Screenshots (if appropriate):


[DX-376]: https://contentful.atlassian.net/browse/DX-376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ