### PR TITLE
fix: update env alias update command description [DX-369]

### DIFF
--- a/docs/space/environment-alias/update/README.md
+++ b/docs/space/environment-alias/update/README.md
@@ -6,9 +6,9 @@ Change the target environment of the alias.
 
 ```
 Options:
-  --alias-id, -a               Id of the alias to create              [required]
+  --alias-id, -a               ID of the alias to update              [required]
   --target-environment-id, -e  ID of the target environment             [string]
-  --space-id, -s               ID of the space that the alias will belong to
+  --space-id, -s               ID of the space that the alias belongs to
 ```
 
 ### Example

--- a/lib/cmds/space_cmds/alias_cmds/update.js
+++ b/lib/cmds/space_cmds/alias_cmds/update.js
@@ -14,7 +14,7 @@ module.exports.builder = yargs => {
     )
     .option('alias-id', {
       alias: 'a',
-      describe: 'Id of the alias to create',
+      describe: 'ID of the alias to update',
       demandOption: true
     })
     .option('target-environment-id', {
@@ -24,7 +24,7 @@ module.exports.builder = yargs => {
     })
     .option('space-id', {
       alias: 's',
-      describe: 'ID of the space that the alias will belong to',
+      describe: 'ID of the space that the alias belongs to',
       type: 'string'
     })
     .option('management-token', {


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

Update the `environment-alias update` command description to make it clear that this only supports updating an environment alias by changing the environment target.

## Description

Updated the command description and relevant docs to clarify that this command is only for updating an existing alias, not for creating a new one.

## Motivation and Context

Addresses #3083. Adding support for an `environment-alias create` command is a feature request that in the team backlog that will be addressed separately.

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

- [x] Implemented feature
- [ ] Feature with pending implementation

## Screenshots (if appropriate):
