### PR TITLE
feat: add environment-alias create command [DX-370]

### DIFF
--- a/docs/space/README.md
+++ b/docs/space/README.md
@@ -12,4 +12,4 @@
 - [migration](./migration) - Parses and runs a migration script on a Contentful space.
 - [generate](./generate) - Auto-generate files related to your space. For example, migration scripts.
 - [environment](./environment) - List, create, and delete space environments.
-- [environment-alias](./environment-alias) - List and update space environment aliases.
+- [environment-alias](./environment-alias) - List, create, and update space environment aliases.

--- a/docs/space/environment-alias/README.md
+++ b/docs/space/environment-alias/README.md
@@ -2,5 +2,6 @@
 
 ## Available subcommands:
 
-- [list](./list) - Lists all available Environment Aliases from a Space (currently only 'master').
+- [list](./list) - Lists all available Environment Aliases from a Space
 - [update](./update) - Changes the target Environment of the Environment Alias
+- [create](./create) - Adds a new Environment Alias for a space

--- a/docs/space/environment-alias/create/README.md
+++ b/docs/space/environment-alias/create/README.md
@@ -1,0 +1,20 @@
+# Contentful CLI - `space environment-alias create` command
+
+Create a new environment alias. **NOTE:** You must opt-in to this feature in the Contentful web app on the Settings > Environments page.
+
+## Usage
+
+```
+Options:
+  --alias-id, -a               ID of the alias to create                  [required]
+  --target-environment-id, -e  ID of the target environment               [required]
+  --space-id, -s               ID of the space that the alias belongs to    [string]
+  --management-token, -mt      API management token                         [string]
+  --header, -H                 Pass an additional HTTP Header               [string]
+```
+
+### Example
+
+```sh
+contentful space environment-alias create --alias-id 'staging' --target-environment-id 'release-2'
+```

--- a/docs/space/environment-alias/list/README.md
+++ b/docs/space/environment-alias/list/README.md
@@ -1,12 +1,12 @@
 # Contentful CLI - `space environment-alias list` command
 
-Lists all available Environment Aliases from a Space. At this time the list will either by empty or contain the alias 'master'
+Lists all available Environment Aliases from a Space. **NOTE:** You must opt-in to this feature in the Contentful web app on the Settings > Environments page.
 
 ## Usage
 
 ```
 Options:
-  --space-id            ID of the space that holds the environment alias     [string]
+  --space-id, -s            ID of the space that holds the environment aliases     [string]
 ```
 
 ### Example

--- a/docs/space/environment-alias/update/README.md
+++ b/docs/space/environment-alias/update/README.md
@@ -1,14 +1,16 @@
 # Contentful CLI - `space environment-alias update` command
 
-Change the target environment of the alias.
+Change the target environment of the alias. **NOTE:** You must opt-in to this feature in the Contentful web app on the Settings > Environments page.
 
 ## Usage
 
 ```
 Options:
-  --alias-id, -a               ID of the alias to update              [required]
-  --target-environment-id, -e  ID of the target environment             [string]
-  --space-id, -s               ID of the space that the alias belongs to
+  --alias-id, -a               ID of the alias to update                [required]
+  --target-environment-id, -e  ID of the target environment               [string]
+  --space-id, -s               ID of the space that the alias belongs to  [string]
+  --management-token, -mt      API management token                       [string]
+  --header, -H                 Pass an additional HTTP Header             [string]
 ```
 
 ### Example

--- a/lib/cmds/space_cmds/alias_cmds/create.ts
+++ b/lib/cmds/space_cmds/alias_cmds/create.ts
@@ -1,0 +1,88 @@
+import { Argv } from 'yargs'
+import { handleAsyncError as handle } from '../../../utils/async'
+import { createPlainClient } from '../../../utils/contentful-clients'
+import { getHeadersFromOption } from '../../../utils/headers'
+import logging from '../../../utils/log'
+
+export const command = 'create'
+
+export const desc = 'Create an environment alias'
+
+export const builder = (yargs: Argv) => {
+  return yargs
+    .usage(
+      'Usage: contentful space alias create --alias-id staging --target-environment-id dev-test'
+    )
+    .option('alias-id', {
+      alias: 'a',
+      describe: 'ID of the alias to create',
+      demandOption: true
+    })
+    .option('target-environment-id', {
+      alias: 'e',
+      describe: 'ID of the target environment',
+      type: 'string',
+      demandOption: true
+    })
+    .option('space-id', {
+      alias: 's',
+      describe: 'ID of the space that the alias belongs to',
+      type: 'string'
+    })
+    .option('management-token', {
+      alias: 'mt',
+      describe: 'Contentful management API token',
+      type: 'string'
+    })
+    .option('header', {
+      alias: 'H',
+      type: 'string',
+      describe: 'Pass an additional HTTP Header'
+    })
+}
+
+interface Params {
+  context: {
+    managementToken: string
+    activeSpaceId: string
+  }
+  aliasId: string
+  targetEnvironmentId: string
+  header?: string
+}
+
+export const environmentAliasCreate = async function ({
+  context,
+  aliasId,
+  targetEnvironmentId,
+  header
+}: Params) {
+  const { managementToken, activeSpaceId } = context
+
+  const client = await createPlainClient({
+    accessToken: managementToken,
+    feature: 'space-environment-alias-create',
+    headers: getHeadersFromOption(header)
+  })
+
+  const alias = await client.environmentAlias.createWithId(
+    { spaceId: activeSpaceId, environmentAliasId: aliasId },
+    {
+      environment: {
+        sys: {
+          type: 'Link',
+          linkType: 'Environment',
+          id: targetEnvironmentId
+        }
+      }
+    }
+  )
+
+  logging.success(
+    `Successfully created environment alias ${alias.sys.id} targeting environment ${alias.environment.sys.id}`
+  )
+
+  return alias
+}
+
+export const handler = handle(environmentAliasCreate)

--- a/test/unit/cmds/space_cmds/alias_cmds/create.test.ts
+++ b/test/unit/cmds/space_cmds/alias_cmds/create.test.ts
@@ -1,0 +1,58 @@
+import { environmentAliasCreate } from '../../../../../lib/cmds/space_cmds/alias_cmds/create'
+import { createPlainClient } from '../../../../../lib/utils/contentful-clients'
+
+jest.mock('../../../../../lib/utils/contentful-clients')
+
+const environmentData = {
+  sys: {
+    type: 'Environment',
+    id: 'envId'
+  }
+}
+
+const environmentAliasData = {
+  sys: {
+    id: 'mockedAliasId'
+  },
+  environment: environmentData
+}
+
+const fakeClient = {
+  environmentAlias: {
+    createWithId: jest.fn().mockResolvedValue(environmentAliasData)
+  }
+}
+
+const mockCreatePlainClient = (
+  createPlainClient as unknown as jest.Mock
+).mockResolvedValue(fakeClient)
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+test('create environment alias', async () => {
+  await environmentAliasCreate({
+    aliasId: 'alias-id',
+    targetEnvironmentId: 'target-env-id',
+    context: {
+      activeSpaceId: 'someSpaceID',
+      managementToken: 'mockedToken'
+    }
+  })
+
+  expect(mockCreatePlainClient).toHaveBeenCalledTimes(1)
+  expect(fakeClient.environmentAlias.createWithId).toHaveBeenCalledTimes(1)
+  expect(fakeClient.environmentAlias.createWithId).toHaveBeenCalledWith(
+    { spaceId: 'someSpaceID', environmentAliasId: 'alias-id' },
+    {
+      environment: {
+        sys: {
+          type: 'Link',
+          linkType: 'Environment',
+          id: 'target-env-id'
+        }
+      }
+    }
+  )
+})


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

This PR adds a new command to allow for creating a new environment alias from the CLI.

## Description

Customers will now be able to create a new environment alias from the CLI, for example:

```
contentful space environment-alias create --alias-id 'staging' --target-environment-id 'release-2'
```

Also updated docs for all of the environment-alias commands

## Motivation and Context

The CLI allowed for listing and updating an alias, now customers can add a new alias from the CLI.

Tested a few different scenarios with this new feature:
- Tested this new functionality in US and EU spaces
- Tested when a space doesn't have environment aliases available (returns an error message)
- Tested when a space has reached the limit of available environment aliases (returns an error message)

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

- [x] Implemented feature
- [ ] Feature with pending implementation

## Screenshots (if appropriate):
