### PR TITLE
fix: bump axios to 1.12.2 [DX-427]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "@typescript-eslint/eslint-plugin": "^5.31.0",
         "@typescript-eslint/parser": "^5.31.0",
         "app-root-path": "^3.0.0",
-        "axios": "^1.3.4",
+        "axios": "^1.12.2",
         "babel-jest": "^29.4.3",
         "concurrently": "^9.0.0",
         "cross-env": "^7.0.2",
@@ -4944,10 +4944,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.1.tgz",
-      "integrity": "sha512-Kn4kbSXpkFHCGE6rBFNwIv0GQs4AvDT80jlveJDKFxjbTYMUeB4QtsdPCv6H8Cm19Je7IU6VFtRl2zWZI0rudQ==",
-      "license": "MIT",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@typescript-eslint/eslint-plugin": "^5.31.0",
     "@typescript-eslint/parser": "^5.31.0",
     "app-root-path": "^3.0.0",
-    "axios": "^1.3.4",
+    "axios": "^1.12.2",
     "babel-jest": "^29.4.3",
     "concurrently": "^9.0.0",
     "cross-env": "^7.0.2",


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

- Bump axios version to stable version to address security vulnerabilities

## Description

<!-- Describe your changes in detail -->

Bumps both package.json and package-lock.json axios version to 1.12.2

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

- [ ] Implemented feature
- [ ] Feature with pending implementation

## Screenshots (if appropriate):
