### PR TITLE
chore(dependabot): add deps to ignore []

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,21 @@ updates:
     - dependency-name: semantic-release
       versions:
         - ">=23.0.0"
+    # Pure ESM package. Remove from ignore when ESM is supported
+    # https://github.com/SBoudrias/Inquirer.js/releases/tag/inquirer%409.0.0
+    - dependency-name: inquirer 
+      versions:
+        - ">=9.0.0"
+    # Pure ESM package. Remove from ignore when ESM is supported
+    # https://github.com/sindresorhus/p-queue/releases/tag/v7.0.0
+    - dependency-name: p-queue
+      versions:
+        - ">=7.0.0"
+    # Pure ESM package. Remove from ignore when ESM is supported
+    #https://github.com/sindresorhus/open/releases/tag/v9.0.0
+    - dependency-name: open
+      versions:
+        - ">=9.0.0"
     commit-message:
       prefix: build
       include: scope


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

Adds dependencies to dependabot ignore list.

## Description

Dependencies added to ignore are now pure ESM packages.

## Motivation and Context

This PR lets dependabot ignore them for now in order to declutter the open pull requests. However, we should consider a rewrite to ESM or making changes to support pure ESM packages in the future.

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

- [x] Implemented feature
- [ ] Feature with pending implementation

## Screenshots (if appropriate):
