### PR TITLE
chore: gha policies updated in vault secrets [DX-535]

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -3,6 +3,8 @@ services:
   github-action:
     policies:
       - dependabot
+      - semantic-release
+      - packages-read
   circleci:
     policies:
       - semantic-release-ecosystem


### PR DESCRIPTION
This PR updates the vault-secrets config file so that we can correctly test the publishing workflow on the DX-535-gha-publishing branch.
