### PR TITLE
chore: remove unused secret in check workflow [DX-717]

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -5,8 +5,6 @@ permissions:
 on:
   workflow_call:
     secrets:
-      VAULT_URL:
-        required: true
       CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN:
         required: true
       CLI_E2E_ORG_ID:


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

Remove unused secret VAULT_URL from CI/check workflow. Dependabot PRs are failing because they do not have access to this in the workflow, but turns out it's not used in the check workflow anyway.

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

- [x] Implemented feature
- [ ] Feature with pending implementation

## Screenshots (if appropriate):
