### PR TITLE
chore: fail on cache miss during restore build folders step [DX-729]

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -36,6 +36,7 @@ jobs:
             dist
             build
           key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
+          fail-on-cache-miss: true
 
       # Prior ci publishing did not lint or format, commented out to preserve workflow
       # - name: Run linter

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,6 +63,7 @@ jobs:
             dist
             build
           key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
+          fail-on-cache-miss: true
       - name: Run Release
         run: |
           echo "Starting Semantic Release Process"

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -43,6 +43,7 @@ jobs:
                       dist
                       build
                   key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
+                  fail-on-cache-miss: true
 
             - name: Run e2e tests
               run: chmod +x build/contentful-cli-* && npm run test:e2e


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.


PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>.

If this is an urgent issue you are having with Contentful it's better to contact
support@contentful.com.
-->

## Summary

Adds `fail-on-cache-miss` to the `restore the build folders` step in our CI workflows to exit a workflow on a cache miss.

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

- [x] Implemented feature
- [ ] Feature with pending implementation

## Screenshots (if appropriate):
