### PR TITLE
fix: workaround broken createWithId by using updatePut(version: 0) [DX-967]

### DIFF
--- a/lib/cmds/organization_cmds/taxonomy/taxonomy-import.ts
+++ b/lib/cmds/organization_cmds/taxonomy/taxonomy-import.ts
@@ -47,10 +47,15 @@ const taxonomyImport = async (
                     omit(concept, ['broader', 'related'])
                   )
                 }
-                return ctx.cmaClient.concept.createWithId(
+                // createWithId is broken in contentful-management — it sends no X-Contentful-Version
+                // header, which the API requires on all taxonomy PUT requests. Use updatePut(version: 0)
+                // instead: same PUT endpoint, but correctly sends the header. See DX-967.
+                // TODO: revert to createWithId once the SDK fixes its implementation.
+                return ctx.cmaClient.concept.updatePut(
                   {
                     organizationId: organizationId,
-                    conceptId: concept.sys.id
+                    conceptId: concept.sys.id,
+                    version: 0
                   },
                   omit(concept, ['broader', 'related'])
                 )
@@ -135,10 +140,13 @@ const taxonomyImport = async (
                       conceptScheme
                     )
                   }
-                  return ctx.cmaClient.conceptScheme.createWithId(
+                  // Same SDK workaround as concept create path above. See DX-967.
+                  // TODO: revert to createWithId once the SDK fixes its implementation.
+                  return ctx.cmaClient.conceptScheme.updatePut(
                     {
                       organizationId: organizationId,
-                      conceptSchemeId: conceptScheme.sys.id
+                      conceptSchemeId: conceptScheme.sys.id,
+                      version: 0
                     },
                     conceptScheme
                   )

--- a/lib/cmds/organization_cmds/taxonomy/taxonomy-import.ts
+++ b/lib/cmds/organization_cmds/taxonomy/taxonomy-import.ts
@@ -48,14 +48,14 @@ const taxonomyImport = async (
                   )
                 }
                 // createWithId is broken in contentful-management — it sends no X-Contentful-Version
-                // header, which the API requires on all taxonomy PUT requests. Use updatePut(version: 0)
+                // header, which the API requires on all taxonomy PUT requests. Use updatePut(version: 1)
                 // instead: same PUT endpoint, but correctly sends the header. See DX-967.
                 // TODO: revert to createWithId once the SDK fixes its implementation.
                 return ctx.cmaClient.concept.updatePut(
                   {
                     organizationId: organizationId,
                     conceptId: concept.sys.id,
-                    version: 0
+                    version: 1
                   },
                   omit(concept, ['broader', 'related'])
                 )
@@ -146,7 +146,7 @@ const taxonomyImport = async (
                     {
                       organizationId: organizationId,
                       conceptSchemeId: conceptScheme.sys.id,
-                      version: 0
+                      version: 1
                     },
                     conceptScheme
                   )

--- a/test/integration/cmds/organization/taxonomy-import.test.ts
+++ b/test/integration/cmds/organization/taxonomy-import.test.ts
@@ -23,28 +23,31 @@ describe('organization import', () => {
     cmaClient = createClient({ accessToken }, { type: 'plain' })
   })
   afterAll(async () => {
-    await Promise.allSettled([
-      cmaClient.conceptScheme.delete({
-        organizationId,
-        conceptSchemeId: 'scheme0',
-        version: 2
-      }),
-      cmaClient.concept.delete({
-        organizationId,
-        conceptId: 'concept2',
-        version: 1
-      }),
-      cmaClient.concept.delete({
-        organizationId,
-        conceptId: 'concept1',
-        version: 2
-      }),
-      cmaClient.concept.delete({
-        organizationId,
-        conceptId: 'concept0',
-        version: 3
-      })
-    ])
+    const conceptDeletes = ['concept0', 'concept1', 'concept2'].map(conceptId =>
+      cmaClient.concept
+        .get({ organizationId, conceptId })
+        .then(c =>
+          cmaClient.concept.delete({
+            organizationId,
+            conceptId,
+            version: c.sys.version
+          })
+        )
+        .catch(() => {})
+    )
+    const schemeDeletes = ['scheme0'].map(conceptSchemeId =>
+      cmaClient.conceptScheme
+        .get({ organizationId, conceptSchemeId })
+        .then(s =>
+          cmaClient.conceptScheme.delete({
+            organizationId,
+            conceptSchemeId,
+            version: s.sys.version
+          })
+        )
+        .catch(() => {})
+    )
+    await Promise.allSettled([...conceptDeletes, ...schemeDeletes])
   })
 
   test('should print help message', done => {

--- a/test/unit/cmds/organization_cmds/import.test.ts
+++ b/test/unit/cmds/organization_cmds/import.test.ts
@@ -148,7 +148,11 @@ afterEach(() => {
   jest.clearAllMocks()
 })
 
-test('initializes client w/ taxonomy data - createWithId', async () => {
+// TODO(DX-967): re-enable when contentful-management fixes concept.createWithId /
+// conceptScheme.createWithId to send X-Contentful-Version header. The CLI works around
+// the broken SDK methods by using updatePut(version: 0) for new entities — see taxonomy-import.ts.
+// Once the SDK is fixed, revert the source and this test.
+test.skip('initializes client w/ taxonomy data - createWithId', async () => {
   mockReadContentFile.mockResolvedValue({
     taxonomy: {
       concepts: [
@@ -197,9 +201,17 @@ test('initializes client w/ taxonomy data - updatePut', async () => {
   expect(mockReadContentFile).toHaveBeenCalledTimes(1)
   expect(fakeClient.concept.createWithId).toHaveBeenCalledTimes(0)
   expect(fakeClient.concept.updatePut).toHaveBeenCalledTimes(2)
+  expect(fakeClient.concept.updatePut).toHaveBeenCalledWith(
+    expect.objectContaining({ version: 1 }),
+    expect.anything()
+  )
   expect(fakeClient.concept.patch).toHaveBeenCalledTimes(2)
   expect(fakeClient.conceptScheme.createWithId).toHaveBeenCalledTimes(0)
   expect(fakeClient.conceptScheme.updatePut).toHaveBeenCalledTimes(1)
+  expect(fakeClient.conceptScheme.updatePut).toHaveBeenCalledWith(
+    expect.objectContaining({ version: 1 }),
+    expect.anything()
+  )
 })
 
 test('initializes client without taxonomy data', async () => {

--- a/test/unit/cmds/organization_cmds/import.test.ts
+++ b/test/unit/cmds/organization_cmds/import.test.ts
@@ -150,7 +150,7 @@ afterEach(() => {
 
 // TODO(DX-967): re-enable when contentful-management fixes concept.createWithId /
 // conceptScheme.createWithId to send X-Contentful-Version header. The CLI works around
-// the broken SDK methods by using updatePut(version: 0) for new entities — see taxonomy-import.ts.
+// the broken SDK methods by using updatePut(version: 1) for new entities — see taxonomy-import.ts.
 // Once the SDK is fixed, revert the source and this test.
 test.skip('initializes client w/ taxonomy data - createWithId', async () => {
   mockReadContentFile.mockResolvedValue({


### PR DESCRIPTION
[DX-967](https://contentful.atlassian.net/browse/DX-967)

## Summary
- `concept.createWithId` and `conceptScheme.createWithId` in `contentful-management` do not send the `X-Contentful-Version` header, which the API has required on all taxonomy PUT requests since ~Feb 2025. This caused `organization import` to return HTTP 422 on all fresh imports.
- Replaced both create paths with `updatePut(version: 1)` — same PUT endpoint, correctly sends the required header. Comments + TODO markers point back to DX-967 so the workaround is reverted once the SDK is fixed.
- Fixed the integration test teardown to fetch-then-delete instead of hardcoding entity versions, preventing silent delete failures from leaving stale entities that had been masking the broken code path.

## Test plan
- [x] Integration test `taxonomy-import.test.ts` passes (previously failing with 422 on clean test org)
- [x] Unit test `initializes client w/ taxonomy data - createWithId` shows as skipped (not failed)
- [x] Unit test `initializes client w/ taxonomy data - updatePut` passes with version assertions

Generated with [Claude Code](https://claude.com/claude-code)

[DX-967]: https://contentful.atlassian.net/browse/DX-967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR addresses a critical issue where the contentful-management SDK's createWithId methods for taxonomy entities fail to send the required X-Contentful-Version header, causing HTTP 422 errors during fresh organization imports. The solution implements a workaround using updatePut(version: 1) calls and includes test improvements to ensure reliability.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Replaces broken concept.createWithId and conceptScheme.createWithId methods with updatePut(version: 1) in taxonomy-import.ts to work around SDK header omission issue</li>

<li>Updates integration test teardown in taxonomy-import.test.ts to dynamically fetch entity versions before deletion instead of hardcoding them</li>

<li>Modifies unit tests in import.test.ts to skip createWithId test and add version assertions for updatePut calls</li>

</ul>
</details>

</div>