### PR TITLE
Remove missing package main entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "contentful-cli",
   "version": "0.0.0-determined-by-semantic-release",
   "description": "Contentful CLI tool",
-  "main": "dist/contentful.js",
   "bin": {
     "contentful": "bin/contentful.js"
   },


### PR DESCRIPTION
## Summary

- remove the package `main` entry that points to `dist/contentful.js`
- keep the existing `bin.contentful` CLI entry unchanged

## Why

`contentful-cli` is published as a CLI package, but its package metadata currently advertises `dist/contentful.js` as the package main. That file is not present in the repository or published package tarball, so consumers and package validators see a broken entry point.

The CLI entry remains `bin/contentful.js`, which loads `dist/lib/cli.js` after the package build.

Fixes #3285.

## Validation

- `node -e "const p=require('./package.json'); console.log({hasMain:Object.prototype.hasOwnProperty.call(p,'main'), bin:p.bin})"`
- `npm pack --dry-run --json .`
- packed tarball `package/package.json` inspection confirmed no `main` entry and unchanged `bin.contentful`
- `git diff --check`
