### PR TITLE
ci: support fork PRs via environment-gated secrets [DX-1292]

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,6 +4,10 @@ permissions:
   contents: read
 on:
   workflow_call:
+    inputs:
+      environment:
+        type: string
+        required: false
     secrets:
       CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN:
         required: true
@@ -13,6 +17,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/fork-ci.yaml
+++ b/.github/workflows/fork-ci.yaml
@@ -1,0 +1,24 @@
+name: fork-ci
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: ['**']
+
+jobs:
+  build:
+    if: github.event.pull_request.head.repo.fork == true
+    uses: ./.github/workflows/build.yaml
+
+  check:
+    needs: build
+    uses: ./.github/workflows/check.yaml
+    with:
+      environment: fork-ci
+
+  e2e-tests:
+    needs: [build, check]
+    uses: ./.github/workflows/test-e2e.yaml
+    with:
+      environment: fork-ci

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == false
     uses: ./.github/workflows/build.yaml
 
   check:

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -4,6 +4,10 @@ permissions:
     contents: read
 on:
     workflow_call:
+        inputs:
+            environment:
+                type: string
+                required: false
         secrets:
             CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN:
                 required: true
@@ -12,6 +16,7 @@ on:
 
 jobs:
     e2e-tests:
+        environment: ${{ inputs.environment }}
         strategy:
             max-parallel: 1
             matrix:


### PR DESCRIPTION
## Summary

  - Adds a `fork-ci.yaml` workflow that runs for PRs opened from forks,
    routing `check` and `e2e-tests` jobs through a `fork-ci` GitHub
    environment so secrets are injected after maintainer approval
  - Updates `check.yaml` and `test-e2e.yaml` to accept an optional
    `environment` input, removing the hard `required: true` on secrets
    (they still resolve normally for internal PRs — the input defaults to `''`)
  - Gates `main.yaml` to skip fork PRs so both workflows don't fire on the
    same event

  ## How it works

  When an external contributor opens a fork PR, `fork-ci.yaml` triggers.
  The `build` job runs immediately. The `check` and `e2e-tests` jobs pause
  at the `fork-ci` environment gate until a maintainer approves — at which
  point `CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN` and `CLI_E2E_ORG_ID` are
  injected from environment secrets and the jobs proceed normally.

  Internal PRs are unaffected — `main.yaml` still runs with `secrets: inherit`.

  ## Pre-requisites (manual setup required before merging)

  - [x] Create a `fork-ci` environment in repo Settings → Environments
  - [x] Add `CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN` and `CLI_E2E_ORG_ID`
        as secrets on that environment
  - [ ] Enable **required reviewers** on the environment (critical — without
        this gate, fork code runs with live secrets unreviewed)

  ## Test plan

  - [ ] Open a test PR from a fork and confirm `fork-ci` workflow triggers
        and pauses at the environment gate
  - [ ] Approve the environment deployment and confirm jobs complete
  - [ ] Confirm an internal PR still runs `main.yaml` only 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR implements a secure fork PR CI pipeline for external contributors by introducing a new fork-ci.yaml workflow, updating existing reusable workflows to accept environment inputs, and gating main.yaml to prevent duplicate runs on fork PRs.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces fork-ci.yaml workflow that triggers for fork PRs (github.event.pull_request.head.repo.fork == true), routing build/check/e2e-tests jobs through a fork-ci GitHub environment for maintainer-approved secret injection</li>

<li>Adds optional environment input to check.yaml and test-e2e.yaml reusable workflows, enabling environment-gated secret injection while preserving existing behavior for internal PRs</li>

<li>Gates main.yaml to skip fork PRs via conditional check on fork status, preventing duplicate CI runs when fork-ci.yaml is active</li>

</ul>
</details>

</div>