### PR TITLE
ci: skip e2e tests for forked repos [AIS-99]

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,6 +21,7 @@ jobs:
     secrets: inherit
 
   e2e-tests:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == false
     needs: [build, check]
     uses: ./.github/workflows/test-e2e.yaml
     secrets: inherit


### PR DESCRIPTION
## Summary
Skip e2e tests for forked repos.

**Problem statement:**
1. our repos often restrict write access :lock:  which is a good idea.  However, this requires external contributors to fork our repos.
2. our repos have e2e tests :test_tube: which are gated by a maintainer to run the e2e tests from a PR.  However these tests have env vars like: CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN, CONTENTFUL_ORGANIZATION_ID  etc.
3. those env vars are defined as repo-scoped github action secrets.
4. PRs originating from forked repos run their github actions in their own context :scream_cat: so the env vars do not get injected, causing the e2e tests to fail.


**Solution**

👍  skip e2e tests for forked PRs
~~Environment-Gated Secrets~~
~~create a new github env: fork-ci~~
~~create a new fork-ci.yaml  github action to run just for PRs from forked repos, that runs in that env, by passing~~ ~~environment: fork-ci as an input~~

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

- [x] Implemented feature
- [ ] Feature with pending implementation

## Screenshots (if appropriate): 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR introduces a conditional skip mechanism to the e2e-tests job in the GitHub Actions workflow, preventing test failures for pull requests originating from forked repositories. The change addresses the issue where external contributors cannot trigger e2e tests due to repository-scoped GitHub Action secrets being unavailable in the fork's context.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds `if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == false` condition to the e2e-tests job in main.yaml, ensuring tests only run for direct pushes and internal PRs.</li>

<li>Prevents e2e test failures for external contributors by skipping execution when repository-scoped GitHub Action secrets are inaccessible in the fork's context.</li>

<li>Allows maintainers to merge external contributor PRs without test failures while preserving e2e test coverage for direct pushes and internal pull requests.</li>

</ul>
</details>

</div>