### PR TITLE
Ci e2e secrets optional [AIS-96]

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -38,15 +38,11 @@ jobs:
           key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
           fail-on-cache-miss: true
 
-      # Prior ci publishing did not lint or format, commented out to preserve workflow
       # - name: Run linter
       #   run: npm run lint
 
-      #- name: Check formatting
-      #  run: npm run prettier:check
-      #  env:
-      #    CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN: ${{ secrets.CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN }}
-      #    CLI_E2E_ORG_ID: ${{ secrets.CLI_E2E_ORG_ID }}
+      # - name: Check formatting
+      #   run: npm run prettier:check
 
       - name: Run unit tests
         run: npm test

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,9 +6,9 @@ on:
   workflow_call:
     secrets:
       CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN:
-        required: true
+        required: false
       CLI_E2E_ORG_ID:
-        required: true
+        required: false
 
 jobs:
   check:
@@ -55,6 +55,7 @@ jobs:
           CLI_E2E_ORG_ID: ${{ secrets.CLI_E2E_ORG_ID }}
 
       - name: Run integration tests
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == false
         run: npm run test:integration:ci
         env:
           CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN: ${{ secrets.CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN }}


### PR DESCRIPTION
## Summary
1. CI: reenable formating/linting
2. Make env vars as optional for `check.yaml`, since it is only required for integration testing, and add a gate to only execute integration tests for **non** forked PRs


<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

- [x] Implemented feature
- [ ] Feature with pending implementation

## Screenshots (if appropriate): 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR updates the CI workflow configuration to make integration test secrets optional, re-enables formatting and linting checks, and adds a condition to skip integration tests on forked PRs to prevent CI failures for external contributors.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Makes CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN and CLI_E2E_ORG_ID secrets optional (required: false) in the workflow_call definition instead of required</li>

<li>Re-enables the linter and prettier formatting checks that were previously commented out in check.yaml</li>

<li>Removes environment variable passthrough (CMA_TOKEN and ORG_ID) from the unit tests job since those secrets are no longer required</li>

<li>Adds conditional if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == false to the integration tests step to skip execution on forked PRs</li>

</ul>
</details>

</div>