### PR TITLE
chore: bump contentful-export [AIS-324]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "command-exists": "^1.2.7",
         "contentful-batch-libs": "^11.0.0",
         "contentful-collection": "^0.0.4",
-        "contentful-export": "^8.0.0",
+        "contentful-export": "^8.1.1",
         "contentful-import": "10.0.0",
         "contentful-management": "^12.2.0",
         "contentful-migration": "^5.0.0",
@@ -7709,9 +7709,9 @@
       "integrity": "sha512-AvrnEeMTJtRy9SeuHrLbk/bntLwEE9FrhPfFcBp08md0Nz3N7a2+SmZgF5ZTyBRVc9pHjg+Fg6+O5c9q7Tj5HQ=="
     },
     "node_modules/contentful-export": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/contentful-export/-/contentful-export-8.0.0.tgz",
-      "integrity": "sha512-wYGY3B1Ly91ecNU+dFEDzkYcSqY0OnSVFOgrJWsOH/9dIT2Lm9vFwLJTM9qESsd3d8a3sCAonE56UgRqmSKbYg==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/contentful-export/-/contentful-export-8.1.1.tgz",
+      "integrity": "sha512-YGXv/SyzU2iDoHLq+VRfkQX+dCKcjWviFFQNcc7e2aav5s15aWXapG7Loxp1II1UHFr5WpvPZ4l7+m6Cz7U9hA==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.5",
@@ -7719,7 +7719,7 @@
         "bluebird": "^3.3.3",
         "cli-table3": "^0.6.0",
         "contentful": "^11.5.10",
-        "contentful-batch-libs": "^10.1.3",
+        "contentful-batch-libs": "^12.0.0",
         "contentful-management": "^12.2.0",
         "date-fns": "^4.1.0",
         "figures": "^3.2.0",
@@ -7774,9 +7774,9 @@
       }
     },
     "node_modules/contentful-export/node_modules/contentful-batch-libs": {
-      "version": "10.1.6",
-      "resolved": "https://registry.npmjs.org/contentful-batch-libs/-/contentful-batch-libs-10.1.6.tgz",
-      "integrity": "sha512-tJSakKopOV8ZZ1o2G2YkqhQX8N/puVof8pBDipsRaqPPfJYLdooTWwCN1xPPhPVI0gGw8Twyc1s18CJrWhHzWg==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/contentful-batch-libs/-/contentful-batch-libs-12.0.2.tgz",
+      "integrity": "sha512-+xye3iE3yeOMKmLQXrpAkRyg0pwvOVz4TpgWXWQUl2FWCRAH/cLHtS4UDR3WYUTp4fKpkeWIu2tZYy6h7f9MGA==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^2.28.0",
@@ -7785,7 +7785,7 @@
         "uuid": "^11.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/contentful-export/node_modules/contentful-batch-libs/node_modules/date-fns": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "command-exists": "^1.2.7",
     "contentful-batch-libs": "^11.0.0",
     "contentful-collection": "^0.0.4",
-    "contentful-export": "^8.0.0",
+    "contentful-export": "^8.1.1",
     "contentful-import": "10.0.0",
     "contentful-management": "^12.2.0",
     "contentful-migration": "^5.0.0",


### PR DESCRIPTION
https://contentful.atlassian.net/browse/AIS-324

This PR bumps the contentful-export package to its most recent version to fix the bug described in the ticket when using the cli. The commit that fixed this in the export package, triggering the 8.1.1 release is: https://github.com/contentful/contentful-export/commit/402152b5bdf2abb5ae159544506728bf77d6edc0. 
