### PR TITLE
Create a dev/exo build [AIS-136]

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
         run: ls -la dist/
 
       - name: Save Build folders
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: |
             dist

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -30,7 +30,7 @@ jobs:
           npx allow-scripts
 
       - name: Restore the build folders
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: |
             dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
           npx allow-scripts
 
       - name: Restore the build folders
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: |
             dist

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -35,7 +35,7 @@ jobs:
                   npx allow-scripts
 
             - name: Restore the build folders
-              uses: actions/cache/restore@v4
+              uses: actions/cache/restore@v6
               with:
                   path: |
                       dist

--- a/lib/cmds/space_cmds/export.js
+++ b/lib/cmds/space_cmds/export.js
@@ -156,6 +156,11 @@ module.exports.builder = function (yargs) {
       type: 'boolean',
       default: false
     })
+    .option('include-experience-orchestration', {
+      describe: 'Include Experience Orchestration entities (Components, Experience Templates, Data Assemblies, Experience Fragments, Experiences, Design Tokens). Requires exo_m1 entitlement on the source space.',
+      type: 'boolean',
+      default: true
+    })
     .config(
       'config',
       'An optional configuration JSON file containing all the options for a single run'

--- a/lib/cmds/space_cmds/import.ts
+++ b/lib/cmds/space_cmds/import.ts
@@ -108,6 +108,11 @@ export const builder = (yargs: Argv) => {
         'Path to a directory with an asset export made using the --downloadAssets option of the export. Requires `uploadAssets`',
       type: 'string'
     })
+    .option('include-experience-orchestration', {
+      describe: 'Import Experience Orchestration entities (designTokens, components, experienceTemplates, experienceFragments, dataAssemblies, experiences). Requires a space with ExO enabled.',
+      type: 'boolean',
+      default: true
+    })
     .config(
       'config',
       'An optional configuration JSON file containing all the options for a single run'

--- a/test/integration/cmds/space/__snapshots__/import.test.js.snap
+++ b/test/integration/cmds/space/__snapshots__/import.test.js.snap
@@ -4,40 +4,56 @@ exports[`should exit 1 when no args: wrong response in case of no args provided 
 "Usage: contentful space import --content-file <file>
 
 Options:
-  -h, --help                 Show help                                 [boolean]
-  --space-id                 ID of the destination space                [string]
-  --environment-id           ID the environment in the destination space[string]
-  --management-token, --mt   Contentful management API token            [string]
-  --content-file             JSON file that contains data to import into a space
-                                                             [string] [required]
-  --content-model-only       Import only content types[boolean] [default: false]
-  --skip-content-model       Skip importing content types and locales
+  -h, --help                          Show help                        [boolean]
+  --space-id                          ID of the destination space       [string]
+  --environment-id                    ID the environment in the destination
+                                      space                             [string]
+  --management-token, --mt            Contentful management API token   [string]
+  --content-file                      JSON file that contains data to import
+                                      into a space           [string] [required]
+  --content-model-only                Import only content types
                                                       [boolean] [default: false]
-  --skip-locales             Skip importing locales   [boolean] [default: false]
-  --skip-content-publishing  Skips content publishing. Creates content but does
-                             not publish it           [boolean] [default: false]
-  --skip-content-updates     Skips updating existing content, only creates new
-                             entries.                 [boolean] [default: false]
-  --skip-asset-updates       Skips updating existing assets, only creates new
-                             assets.                  [boolean] [default: false]
-  --error-log-file           Full path to the error log file            [string]
-  --host                     Management API host                        [string]
-  --proxy                    Proxy configuration in HTTP auth format:
-                             [http|https]://host:port or
-                             [http|https]://user:password@host:port     [string]
-  --timeout                  Timeout in milliseconds for API calls
+  --skip-content-model                Skip importing content types and locales
+                                                      [boolean] [default: false]
+  --skip-locales                      Skip importing locales
+                                                      [boolean] [default: false]
+  --skip-content-publishing           Skips content publishing. Creates content
+                                      but does not publish it
+                                                      [boolean] [default: false]
+  --skip-content-updates              Skips updating existing content, only
+                                      creates new entries.
+                                                      [boolean] [default: false]
+  --skip-asset-updates                Skips updating existing assets, only
+                                      creates new assets.
+                                                      [boolean] [default: false]
+  --error-log-file                    Full path to the error log file   [string]
+  --host                              Management API host               [string]
+  --proxy                             Proxy configuration in HTTP auth format:
+                                      [http|https]://host:port or
+                                      [http|https]://user:password@host:port
+                                                                        [string]
+  --timeout                           Timeout in milliseconds for API calls
                                                        [number] [default: 20000]
-  --retry-limit              How many times to retry before an operation fails
-                                                          [number] [default: 10]
-  --header, -H               Pass an additional HTTP Header             [string]
-  --upload-assets            Upload local asset files downloaded via the
-                             --downloadAssets option of the export. Requires
-                             \`assetsDirectory\`        [boolean] [default: false]
-  --assets-directory         Path to a directory with an asset export made using
-                             the --downloadAssets option of the export. Requires
-                             \`uploadAssets\`                             [string]
-  --config                   An optional configuration JSON file containing all
-                             the options for a single run
+  --retry-limit                       How many times to retry before an
+                                      operation fails     [number] [default: 10]
+  --header, -H                        Pass an additional HTTP Header    [string]
+  --upload-assets                     Upload local asset files downloaded via
+                                      the --downloadAssets option of the export.
+                                      Requires \`assetsDirectory\`
+                                                      [boolean] [default: false]
+  --assets-directory                  Path to a directory with an asset export
+                                      made using the --downloadAssets option of
+                                      the export. Requires \`uploadAssets\`
+                                                                        [string]
+  --include-experience-orchestration  Import Experience Orchestration entities
+                                      (designTokens, components,
+                                      experienceTemplates, experienceFragments,
+                                      dataAssemblies, experiences). Requires a
+                                      space with ExO enabled.
+                                                       [boolean] [default: true]
+  --config                            An optional configuration JSON file
+                                      containing all the options for a single
+                                      run
 
 Copyright 2013 Contentful
 Missing required argument: content-file"
@@ -47,40 +63,56 @@ exports[`should print help message: help data is incorrect 1`] = `
 "Usage: contentful space import --content-file <file>
 
 Options:
-  -h, --help                 Show help                                 [boolean]
-  --space-id                 ID of the destination space                [string]
-  --environment-id           ID the environment in the destination space[string]
-  --management-token, --mt   Contentful management API token            [string]
-  --content-file             JSON file that contains data to import into a space
-                                                             [string] [required]
-  --content-model-only       Import only content types[boolean] [default: false]
-  --skip-content-model       Skip importing content types and locales
+  -h, --help                          Show help                        [boolean]
+  --space-id                          ID of the destination space       [string]
+  --environment-id                    ID the environment in the destination
+                                      space                             [string]
+  --management-token, --mt            Contentful management API token   [string]
+  --content-file                      JSON file that contains data to import
+                                      into a space           [string] [required]
+  --content-model-only                Import only content types
                                                       [boolean] [default: false]
-  --skip-locales             Skip importing locales   [boolean] [default: false]
-  --skip-content-publishing  Skips content publishing. Creates content but does
-                             not publish it           [boolean] [default: false]
-  --skip-content-updates     Skips updating existing content, only creates new
-                             entries.                 [boolean] [default: false]
-  --skip-asset-updates       Skips updating existing assets, only creates new
-                             assets.                  [boolean] [default: false]
-  --error-log-file           Full path to the error log file            [string]
-  --host                     Management API host                        [string]
-  --proxy                    Proxy configuration in HTTP auth format:
-                             [http|https]://host:port or
-                             [http|https]://user:password@host:port     [string]
-  --timeout                  Timeout in milliseconds for API calls
+  --skip-content-model                Skip importing content types and locales
+                                                      [boolean] [default: false]
+  --skip-locales                      Skip importing locales
+                                                      [boolean] [default: false]
+  --skip-content-publishing           Skips content publishing. Creates content
+                                      but does not publish it
+                                                      [boolean] [default: false]
+  --skip-content-updates              Skips updating existing content, only
+                                      creates new entries.
+                                                      [boolean] [default: false]
+  --skip-asset-updates                Skips updating existing assets, only
+                                      creates new assets.
+                                                      [boolean] [default: false]
+  --error-log-file                    Full path to the error log file   [string]
+  --host                              Management API host               [string]
+  --proxy                             Proxy configuration in HTTP auth format:
+                                      [http|https]://host:port or
+                                      [http|https]://user:password@host:port
+                                                                        [string]
+  --timeout                           Timeout in milliseconds for API calls
                                                        [number] [default: 20000]
-  --retry-limit              How many times to retry before an operation fails
-                                                          [number] [default: 10]
-  --header, -H               Pass an additional HTTP Header             [string]
-  --upload-assets            Upload local asset files downloaded via the
-                             --downloadAssets option of the export. Requires
-                             \`assetsDirectory\`        [boolean] [default: false]
-  --assets-directory         Path to a directory with an asset export made using
-                             the --downloadAssets option of the export. Requires
-                             \`uploadAssets\`                             [string]
-  --config                   An optional configuration JSON file containing all
-                             the options for a single run
+  --retry-limit                       How many times to retry before an
+                                      operation fails     [number] [default: 10]
+  --header, -H                        Pass an additional HTTP Header    [string]
+  --upload-assets                     Upload local asset files downloaded via
+                                      the --downloadAssets option of the export.
+                                      Requires \`assetsDirectory\`
+                                                      [boolean] [default: false]
+  --assets-directory                  Path to a directory with an asset export
+                                      made using the --downloadAssets option of
+                                      the export. Requires \`uploadAssets\`
+                                                                        [string]
+  --include-experience-orchestration  Import Experience Orchestration entities
+                                      (designTokens, components,
+                                      experienceTemplates, experienceFragments,
+                                      dataAssemblies, experiences). Requires a
+                                      space with ExO enabled.
+                                                       [boolean] [default: true]
+  --config                            An optional configuration JSON file
+                                      containing all the options for a single
+                                      run
 
 Copyright 2013 Contentful"
 `;


### PR DESCRIPTION
## Summary
Create an exo build like `npm i contentful-cli@4.0.6-exo.1` that uses the `contentful-export|importX.Y.Z-exo.n` builds.

This will enable Solutions engineers to test with more mature data.

Bonus: 🎉 
Upgrade `actions/cache` from v4 -> v6 to prevent warning that node v20 support will be dropped.
