### PR TITLE
fix(exo): add `include-experience-orchestration` usage params [AIS-96]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,8 @@ You might need to update snapshots and it's challenging with the recordings.
 Tip: run tests without recordings to update the snapshots.
 
 ```
+CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN=<CMA_TOKEN> \
+CLI_E2E_ORG_ID=<ORG_ID> \
 npx jest test/integration/cmds/<path to the affected test file> --updateSnapshot
 ```
 

--- a/lib/cmds/space_cmds/export.js
+++ b/lib/cmds/space_cmds/export.js
@@ -104,6 +104,11 @@ module.exports.builder = function (yargs) {
       type: 'boolean',
       default: false
     })
+    .option('include-experience-orchestration', {
+      describe: 'Include Experience Orchestration entities (Components, Experience Templates, Data Assemblies, Experience Fragments, Experiences, Design Tokens). Requires exo_m1 entitlement on the source space.',
+      type: 'boolean',
+      default: true
+    })
     .option('raw-proxy', {
       describe:
         'Pass proxy config to Axios instead of creating a custom httpsAgent',
@@ -164,7 +169,7 @@ module.exports.builder = function (yargs) {
 }
 
 const exportSpace = async argv => {
-  const { context, feature = 'space-export' } = argv
+  const { context, feature = 'space-export', includeExperienceOrchestration } = argv
   const {
     managementToken,
     activeSpaceId,
@@ -178,6 +183,7 @@ const exportSpace = async argv => {
     ...argv,
     spaceId: activeSpaceId,
     environmentId: activeEnvironmentId,
+    includeExperienceOrchestration,
     managementApplication: `contentful.cli/${version}`,
     managementFeature: feature,
     managementToken,

--- a/lib/cmds/space_cmds/import.ts
+++ b/lib/cmds/space_cmds/import.ts
@@ -64,6 +64,11 @@ export const builder = (yargs: Argv) => {
       type: 'boolean',
       default: false
     })
+    .option('include-experience-orchestration', {
+      describe: 'Import Experience Orchestration entities (designTokens, components, experienceTemplates, experienceFragments, dataAssemblies, experiences). Requires a space with ExO enabled.',
+      type: 'boolean',
+      default: true
+    })
     .option('update', {
       describe: 'Update entries if they already exist',
       type: 'boolean',
@@ -140,6 +145,7 @@ interface ImportSpaceProps {
   content?: object
   uploadAssets?: string
   assetsDirectory?: string
+  includeExperienceOrchestration?: boolean
 }
 
 interface Options {
@@ -154,6 +160,7 @@ interface Options {
   rawProxy?: string
   uploadAssets?: string
   assetsDirectory?: string
+  includeExperienceOrchestration?: boolean
 }
 
 export const importSpace = async (argv: ImportSpaceProps) => {
@@ -165,7 +172,8 @@ export const importSpace = async (argv: ImportSpaceProps) => {
     context,
     feature = 'space-import',
     uploadAssets,
-    assetsDirectory
+    assetsDirectory,
+    includeExperienceOrchestration
   } = argv
   const {
     managementToken,
@@ -192,7 +200,8 @@ export const importSpace = async (argv: ImportSpaceProps) => {
     host,
     headers: getHeadersFromOption(argv.header),
     uploadAssets,
-    assetsDirectory
+    assetsDirectory,
+    includeExperienceOrchestration
   }
 
   if (proxy) {

--- a/test/integration/cmds/space/__snapshots__/import.test.js.snap
+++ b/test/integration/cmds/space/__snapshots__/import.test.js.snap
@@ -4,40 +4,56 @@ exports[`should exit 1 when no args: wrong response in case of no args provided 
 "Usage: contentful space import --content-file <file>
 
 Options:
-  -h, --help                 Show help                                 [boolean]
-  --space-id                 ID of the destination space                [string]
-  --environment-id           ID the environment in the destination space[string]
-  --management-token, --mt   Contentful management API token            [string]
-  --content-file             JSON file that contains data to import into a space
-                                                             [string] [required]
-  --content-model-only       Import only content types[boolean] [default: false]
-  --skip-content-model       Skip importing content types and locales
+  -h, --help                          Show help                        [boolean]
+  --space-id                          ID of the destination space       [string]
+  --environment-id                    ID the environment in the destination
+                                      space                             [string]
+  --management-token, --mt            Contentful management API token   [string]
+  --content-file                      JSON file that contains data to import
+                                      into a space           [string] [required]
+  --content-model-only                Import only content types
                                                       [boolean] [default: false]
-  --skip-locales             Skip importing locales   [boolean] [default: false]
-  --skip-content-publishing  Skips content publishing. Creates content but does
-                             not publish it           [boolean] [default: false]
-  --skip-content-updates     Skips updating existing content, only creates new
-                             entries.                 [boolean] [default: false]
-  --skip-asset-updates       Skips updating existing assets, only creates new
-                             assets.                  [boolean] [default: false]
-  --error-log-file           Full path to the error log file            [string]
-  --host                     Management API host                        [string]
-  --proxy                    Proxy configuration in HTTP auth format:
-                             [http|https]://host:port or
-                             [http|https]://user:password@host:port     [string]
-  --timeout                  Timeout in milliseconds for API calls
+  --skip-content-model                Skip importing content types and locales
+                                                      [boolean] [default: false]
+  --skip-locales                      Skip importing locales
+                                                      [boolean] [default: false]
+  --skip-content-publishing           Skips content publishing. Creates content
+                                      but does not publish it
+                                                      [boolean] [default: false]
+  --skip-content-updates              Skips updating existing content, only
+                                      creates new entries.
+                                                      [boolean] [default: false]
+  --skip-asset-updates                Skips updating existing assets, only
+                                      creates new assets.
+                                                      [boolean] [default: false]
+  --include-experience-orchestration  Import Experience Orchestration entities
+                                      (designTokens, components,
+                                      experienceTemplates, experienceFragments,
+                                      dataAssemblies, experiences). Requires a
+                                      space with ExO enabled.
+                                                       [boolean] [default: true]
+  --error-log-file                    Full path to the error log file   [string]
+  --host                              Management API host               [string]
+  --proxy                             Proxy configuration in HTTP auth format:
+                                      [http|https]://host:port or
+                                      [http|https]://user:password@host:port
+                                                                        [string]
+  --timeout                           Timeout in milliseconds for API calls
                                                        [number] [default: 20000]
-  --retry-limit              How many times to retry before an operation fails
-                                                          [number] [default: 10]
-  --header, -H               Pass an additional HTTP Header             [string]
-  --upload-assets            Upload local asset files downloaded via the
-                             --downloadAssets option of the export. Requires
-                             \`assetsDirectory\`        [boolean] [default: false]
-  --assets-directory         Path to a directory with an asset export made using
-                             the --downloadAssets option of the export. Requires
-                             \`uploadAssets\`                             [string]
-  --config                   An optional configuration JSON file containing all
-                             the options for a single run
+  --retry-limit                       How many times to retry before an
+                                      operation fails     [number] [default: 10]
+  --header, -H                        Pass an additional HTTP Header    [string]
+  --upload-assets                     Upload local asset files downloaded via
+                                      the --downloadAssets option of the export.
+                                      Requires \`assetsDirectory\`
+                                                      [boolean] [default: false]
+  --assets-directory                  Path to a directory with an asset export
+                                      made using the --downloadAssets option of
+                                      the export. Requires \`uploadAssets\`
+                                                                        [string]
+  --config                            An optional configuration JSON file
+                                      containing all the options for a single
+                                      run
 
 Copyright 2013 Contentful
 Missing required argument: content-file"
@@ -47,40 +63,56 @@ exports[`should print help message: help data is incorrect 1`] = `
 "Usage: contentful space import --content-file <file>
 
 Options:
-  -h, --help                 Show help                                 [boolean]
-  --space-id                 ID of the destination space                [string]
-  --environment-id           ID the environment in the destination space[string]
-  --management-token, --mt   Contentful management API token            [string]
-  --content-file             JSON file that contains data to import into a space
-                                                             [string] [required]
-  --content-model-only       Import only content types[boolean] [default: false]
-  --skip-content-model       Skip importing content types and locales
+  -h, --help                          Show help                        [boolean]
+  --space-id                          ID of the destination space       [string]
+  --environment-id                    ID the environment in the destination
+                                      space                             [string]
+  --management-token, --mt            Contentful management API token   [string]
+  --content-file                      JSON file that contains data to import
+                                      into a space           [string] [required]
+  --content-model-only                Import only content types
                                                       [boolean] [default: false]
-  --skip-locales             Skip importing locales   [boolean] [default: false]
-  --skip-content-publishing  Skips content publishing. Creates content but does
-                             not publish it           [boolean] [default: false]
-  --skip-content-updates     Skips updating existing content, only creates new
-                             entries.                 [boolean] [default: false]
-  --skip-asset-updates       Skips updating existing assets, only creates new
-                             assets.                  [boolean] [default: false]
-  --error-log-file           Full path to the error log file            [string]
-  --host                     Management API host                        [string]
-  --proxy                    Proxy configuration in HTTP auth format:
-                             [http|https]://host:port or
-                             [http|https]://user:password@host:port     [string]
-  --timeout                  Timeout in milliseconds for API calls
+  --skip-content-model                Skip importing content types and locales
+                                                      [boolean] [default: false]
+  --skip-locales                      Skip importing locales
+                                                      [boolean] [default: false]
+  --skip-content-publishing           Skips content publishing. Creates content
+                                      but does not publish it
+                                                      [boolean] [default: false]
+  --skip-content-updates              Skips updating existing content, only
+                                      creates new entries.
+                                                      [boolean] [default: false]
+  --skip-asset-updates                Skips updating existing assets, only
+                                      creates new assets.
+                                                      [boolean] [default: false]
+  --include-experience-orchestration  Import Experience Orchestration entities
+                                      (designTokens, components,
+                                      experienceTemplates, experienceFragments,
+                                      dataAssemblies, experiences). Requires a
+                                      space with ExO enabled.
+                                                       [boolean] [default: true]
+  --error-log-file                    Full path to the error log file   [string]
+  --host                              Management API host               [string]
+  --proxy                             Proxy configuration in HTTP auth format:
+                                      [http|https]://host:port or
+                                      [http|https]://user:password@host:port
+                                                                        [string]
+  --timeout                           Timeout in milliseconds for API calls
                                                        [number] [default: 20000]
-  --retry-limit              How many times to retry before an operation fails
-                                                          [number] [default: 10]
-  --header, -H               Pass an additional HTTP Header             [string]
-  --upload-assets            Upload local asset files downloaded via the
-                             --downloadAssets option of the export. Requires
-                             \`assetsDirectory\`        [boolean] [default: false]
-  --assets-directory         Path to a directory with an asset export made using
-                             the --downloadAssets option of the export. Requires
-                             \`uploadAssets\`                             [string]
-  --config                   An optional configuration JSON file containing all
-                             the options for a single run
+  --retry-limit                       How many times to retry before an
+                                      operation fails     [number] [default: 10]
+  --header, -H                        Pass an additional HTTP Header    [string]
+  --upload-assets                     Upload local asset files downloaded via
+                                      the --downloadAssets option of the export.
+                                      Requires \`assetsDirectory\`
+                                                      [boolean] [default: false]
+  --assets-directory                  Path to a directory with an asset export
+                                      made using the --downloadAssets option of
+                                      the export. Requires \`uploadAssets\`
+                                                                        [string]
+  --config                            An optional configuration JSON file
+                                      containing all the options for a single
+                                      run
 
 Copyright 2013 Contentful"
 `;


### PR DESCRIPTION
## Summary
**Fix** a bug where usage params are not explicitly set for `--include-experience-orchestration`, so 

1. `contentful-cli space export|import --help` was not aware of `--include-experience-orchestration`.
2. I'm pretty sure that `--include-experience-orchestration` was defaulting to undefined/false and unintentionally telling export to not include it.


<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

- [x] Implemented feature
- [ ] Feature with pending implementation

## Screenshots (if appropriate):
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This bug fix exposes --include-experience-orchestration in the space export and import CLI commands and explicitly forwards its default-enabled value to the underlying Contentful libraries. It ensures command help output documents the option and prevents the export/import flows from receiving an unintended undefined or false value.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds --include-experience-orchestration to the export builder and passes the parsed setting to contentful-export in export.js, enabling explicit control over Experience Orchestration entity export.</li>

<li>Adds the option and corresponding TypeScript fields to import.ts, then forwards the value to contentful-import so Experience Orchestration entities can be included during imports.</li>

<li>Updates import.test.js.snap to verify the CLI help output includes the new option and its default value.</li>

</ul>
</details>

</div>