### PR TITLE
docs: add AGENTS.md, ARCHITECTURE.md, and first decision record [DX-1299]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ version CI uses.
 | Lint | `npm run lint` (eslint over `bin lib test`) |
 | Format | `npm run prettier:write` |
 | Unit tests | `npm run test:unit` |
-| Unit tests, single path | `npx jest test/unit/cmds/space --verbose` |
+| Unit tests, single path | `npx jest test/unit/cmds/space_cmds --verbose` |
 | Unit tests with coverage (the default `npm test`) | `npm run test:coverage` |
 | Standalone binaries | `npm run build:standalone` |
 | Binaries + zipped release artifacts | `npm run build:package` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,120 @@
+# AGENTS.md
+
+Operating notes for coding agents working in `contentful-cli`. Read this before
+changing anything. For how the pieces fit together see
+[ARCHITECTURE.md](./ARCHITECTURE.md); for commit conventions and the human
+contribution flow see [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## What this repo is
+
+The `contentful` command line tool, published to npm as `contentful-cli` and
+also shipped as standalone binaries for macOS, Linux and Windows. It is a
+[yargs](https://yargs.js.org) CLI written in a mix of TypeScript and JavaScript
+that talks to the Contentful Management API through `contentful-management`.
+
+Owner: `@contentful/team-developer-experience` (see `.github/CODEOWNERS` and
+`catalog-info.yaml`).
+
+## Setup
+
+```sh
+npm install
+```
+
+`.npmrc` sets `ignore-scripts=true`, so lifecycle scripts do **not** run on
+install. If you need them (husky hooks, the `pkg` build's esbuild), run:
+
+```sh
+npx allow-scripts
+```
+
+The allowlist lives under the `lavamoat.allowScripts` key in `package.json`.
+Adding a dependency that needs an install script means adding it there too.
+See [docs/ADRs/2026-08-25-disable-npm-install-scripts-by-default.md](./docs/ADRs/2026-08-25-disable-npm-install-scripts-by-default.md).
+
+Node: `>=22` per `package.json` `engines`; `.nvmrc` pins `24`, which is also the
+version CI uses.
+
+## Commands you will actually need
+
+| Task | Command |
+| --- | --- |
+| Type-check / compile to `dist/` | `npm run tsc` |
+| Lint | `npm run lint` (eslint over `bin lib test`) |
+| Format | `npm run prettier:write` |
+| Unit tests | `npm run test:unit` |
+| Unit tests, single path | `npx jest test/unit/cmds/space --verbose` |
+| Unit tests with coverage (the default `npm test`) | `npm run test:coverage` |
+| Standalone binaries | `npm run build:standalone` |
+| Binaries + zipped release artifacts | `npm run build:package` |
+| Integration tests | `npm run test:integration` |
+| E2E tests (needs a built binary) | `npm run test:e2e` |
+
+`nyc` enforces 80% line coverage (`package.json` → `nyc.check-coverage`), so
+`npm test` fails if your change drops coverage below that.
+
+## Tests need credentials — know which ones you can run
+
+- **Unit tests** (`test/unit/**`) are the only tier you can rely on without
+  Contentful credentials, and even there `CONTRIBUTING.md` notes some currently
+  read the integration env vars.
+- **Integration tests** (`test/integration/**`) run against the `talkback`
+  proxy in `test/proxy.js`, replaying the HTTP tapes in `recordings/`. Recording
+  new tapes requires `CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN` and
+  `CLI_E2E_ORG_ID` for the Ecosystem integration-test org.
+- **E2E tests** (`test/e2e/**`) shell out to the packaged binary in `build/`, so
+  `npm run build:standalone` must have run first.
+
+If you do not have those secrets, say so rather than reporting a test tier as
+passing. Never commit a token into `recordings/`, a snapshot, or a fixture —
+`test/proxy.js` strips `authorization` and `x-contentful-user-agent` headers
+from tapes, and that guarantee only holds if you leave it alone.
+
+## Adding or changing a command
+
+Commands are discovered by yargs `commandDir`, so file placement *is* the
+routing — there is no central registry to update.
+
+1. A top-level command is a module in `lib/cmds/` exporting `command`, `desc`
+   and a `builder` that calls `.commandDir('<name>_cmds')` (see
+   `lib/cmds/space.js`).
+2. A subcommand is a file in the matching `lib/cmds/<name>_cmds/` directory
+   exporting `command`, `desc`, optional `aliases`, `builder`, and `handler`.
+   Wrap the handler in `handleAsyncError` from `lib/utils/async.ts` so failures
+   surface as CLI errors rather than unhandled rejections — `lib/cmds/space_cmds/use.ts`
+   is the reference implementation.
+3. Build API clients with `createManagementClient` / `createPlainClient` from
+   `lib/utils/contentful-clients.js`. Do not call `contentful-management`'s
+   `createClient` directly; the wrappers apply proxy config, `host`, `insecure`
+   and the `contentful.cli/<version>` application header.
+4. If the command works without a login or without an active space, add its
+   full command string (e.g. `'space use'`) to `noAuthNeeded` /
+   `noSpaceIdNeeded` in `lib/config.js`. Otherwise the `assertContext`
+   middleware will reject it.
+5. Add or update the matching page under `docs/<command>/` — `docs/README.md`
+   indexes the command tree and the `docs` directory is shipped in the npm
+   package (`package.json` → `files`).
+
+New code should be TypeScript. The repo is mid-migration (`allowJs: true` in
+`tsconfig.json`, roughly half the files still `.js`); do not bulk-convert
+existing JavaScript as a side effect of an unrelated change.
+
+## Conventions to respect
+
+- Commit messages follow the Angular convention and drive semantic-release.
+  `feat` and `fix` on `main` cut a release; use `docs`, `chore`, `test`, `refactor`
+  or `style` when you do not want one. `build(deps)` is configured to release a
+  patch, so it is not a safe "no release" type here.
+- Prettier config is `.prettierrc`; eslint extends `eslint:recommended`,
+  `prettier` and `plugin:@typescript-eslint/recommended`.
+- User-facing output goes through `lib/utils/log.js` and the helpers in
+  `lib/utils/styles.js` / `lib/utils/emojis.js`, not bare `console.log`.
+
+## Do not
+
+- Do not weaken `.npmrc` or `.gitignore`.
+- Do not commit `dist/`, `build/` or `output/` — all three are gitignored build
+  output.
+- Do not hand-edit `package.json`'s `version`; it is
+  `0.0.0-determined-by-semantic-release` and set at publish time.
+- Do not add reviewers or merge on your own behalf.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,184 @@
+# Architecture
+
+How `contentful-cli` is put together. Aimed at someone about to change it —
+contribution mechanics are in [CONTRIBUTING.md](./CONTRIBUTING.md), agent-specific
+operating rules in [AGENTS.md](./AGENTS.md).
+
+## Shape of the thing
+
+A single Node.js binary entry point that resolves a command from the file tree,
+builds a request context, and calls the Contentful Management API.
+
+```
+bin/contentful.js        →  requires dist/lib/cli.js (compiled output)
+lib/cli.ts               →  yargs bootstrap: usage, commandDir, middleware, help
+lib/cmds/**              →  the command tree (one module per command)
+lib/utils/**             →  clients, logging, context helpers, assertions
+lib/context.js           →  reads/writes ~/.contentfulrc.json
+lib/config.js            →  which commands may skip auth / space id
+lib/core/**              →  event system used by the longer-running commands
+docs/**                  →  per-command reference docs, shipped in the package
+```
+
+`bin/contentful.js` is three lines: a shebang and
+`require('../dist/lib/cli.js')`. Nothing runs from `lib/` directly — TypeScript
+compiles `lib/**` to `dist/` (`tsconfig.json`, `outDir: ./dist`,
+`module: commonjs`, `target: es2016`), so a source change is invisible until
+`npm run tsc` has run.
+
+## Command resolution
+
+`lib/cli.ts` configures yargs and calls `.commandDir('cmds')`. Directory layout
+is the routing table:
+
+- `lib/cmds/<name>.{js,ts}` declares a top-level command and, in its `builder`,
+  calls `.commandDir('<name>_cmds')` to pull in its subcommands.
+- `lib/cmds/<name>_cmds/<sub>.{js,ts}` is a leaf: it exports `command`, `desc`,
+  optional `aliases`, `builder` and `handler`.
+
+Current top-level commands: `config`, `content-type`, `extension`, `feedback`,
+`init`, `login`, `logout`, `merge`, `organization`, `space`, `sync`. The deepest
+nesting is three levels — `space accesstoken`, `space alias`, `space environment`
+and `space generate` each have their own `*_cmds` directory under
+`lib/cmds/space_cmds/`. `organization_cmds` additionally carries two
+non-command support trees, `security_checks/` (the checks behind
+`organization sec-check`) and `taxonomy/`.
+
+Global flags come from `lib/cli.ts`: `-h/--help`, `-v/--version`. `.strict()`
+and `.recommendCommands()` are on, so an unknown flag is an error rather than
+being passed through, and `.fail()` prints help plus the message and exits 1.
+
+## Middleware: context before handlers
+
+Three yargs middlewares in `lib/utils/middlewares.js` run before every handler,
+in order:
+
+1. `getCommand` — joins `yargs.getContext().fullCommands` into a command string
+   like `"space use"`.
+2. `buildContext` — loads persisted config via `lib/context.js`, then layers CLI
+   flags on top: `managementToken`, `spaceId`/`activeSpaceId`,
+   `environmentId`/`activeEnvironmentId`, `host`, `insecure`, `proxy`,
+   `rawProxy`. Defaults `activeEnvironmentId` to `master` and `host` to
+   `api.contentful.com`.
+3. `assertContext` — consults `lib/config.js`. If the command string is not in
+   `noAuthNeeded` it must be logged in; if not in `noSpaceIdNeeded` it must have
+   an active space. This is why adding a command that legitimately runs without
+   a space requires editing `lib/config.js`.
+
+Handlers therefore receive a `context` object and should not re-read config
+themselves.
+
+### Persisted configuration
+
+`lib/context.js` resolves the config file as: `CONTENTFUL_CONFIG_FILE` env
+override → nearest `.contentfulrc.json` found by walking up from cwd
+(`find-up`) → `~/.contentfulrc.json`. Proxy settings are also read from
+`https_proxy`/`http_proxy` (either case), and those env keys are deleted after
+being parsed so `axios` cannot pick them up independently.
+
+## API access
+
+All CMA access funnels through `lib/utils/contentful-clients.js`, which exposes
+two factories over `contentful-management`:
+
+- `createManagementClient` → `createClient(..., { type: 'legacy' })`, the
+  resource-object API most commands use.
+- `createPlainClient` → `createClient(..., { type: 'plain' })` for the
+  endpoint-style API.
+
+Both inject the proxy agent (or raw proxy), `host`, `insecure`, and
+`application: contentful.cli/<version>`. Commands should not construct clients
+any other way — the user agent and proxy behaviour depend on going through here.
+
+Heavier operations delegate to sibling libraries rather than reimplementing
+them: `contentful-export`, `contentful-import`, `contentful-migration` and
+`contentful-batch-libs` are runtime dependencies, and `space export`,
+`space import`, `space migration` and the `organization` import/export commands
+are thin wrappers over them.
+
+## Event system
+
+`lib/core/` holds an RxJS-backed event bus (`lib/core/events/index.js`) with
+`ERROR` / `MESSAGE` / `INTENT` event types, a `MessageDispatcher` scoped per
+subsystem, and two handler trees under `lib/core/event-handlers/`: `logging/`
+renders events to the terminal, `intents/` answers events that need a decision.
+This lets a multi-step flow emit progress and prompts from deep inside itself
+without threading a logger through every call.
+
+Its only consumer today is `lib/cmds/space_cmds/create.ts`, which constructs
+`new EventSystem()` and attaches the two `create-space-handler` modules directly
+rather than going through the `createEventSystem` helper in
+`lib/core/events/create-event-system.js` — that helper currently has no callers
+outside `lib/core/`.
+
+## Testing tiers
+
+`jest.config.js` transpiles both JS and TS through `babel-jest`
+(`babel.config.js` = `preset-env` targeting current node + `preset-typescript`),
+so tests run from source, not from `dist/`.
+
+| Tier | Path | How it gets its data |
+| --- | --- | --- |
+| Unit | `test/unit/**` | mocks, mirroring the `lib/cmds` and `lib/utils` layout |
+| Integration | `test/integration/**` | drives the CLI with `nixt`, HTTP replayed by `talkback` from `recordings/*.json5` |
+| E2E | `test/e2e/**` | `execa` against the packaged binary in `build/` |
+
+`test/proxy.js` starts talkback on port 3333 pointed at `./recordings`, with a
+custom `bodyMatcher` that matches `create-space` tapes on the space name, and an
+`ignoreHeaders` list that keeps `authorization` and user-agent headers out of
+recorded tapes. `npm run test:integration` uses `concurrently` to run the proxy
+and jest together with `--success first --kill-others`.
+
+## Build and release
+
+Two build outputs from one source tree:
+
+1. **npm package** — `npm run tsc` produces `dist/`; `package.json` `files`
+   ships `dist`, `bin`, `output`, `lib`, `docs`, `version.js` and `README.md`,
+   with `bin.contentful` → `bin/contentful.js`.
+2. **Standalone binaries** — `npm run build:standalone` runs `tsc` then
+   `@yao-pkg/pkg`, targeting `node22-{macos,linux,win}-x64` into `build/`
+   (`package.json` → `pkg`). It bundles two assets that cannot be statically
+   resolved: figlet's `Standard.flf` font and `axios`'s node CJS build.
+   `npm run build:package` then runs `script/package`, a small jszip script that
+   wraps each binary as `contentful-cli-<platform>-<version>.zip`.
+
+CI is GitHub Actions, orchestrated by `.github/workflows/main.yaml` on pushes to
+`main`/`beta`/`exo` and on all PRs:
+
+```
+build (build.yaml)  →  check (check.yaml)  →  e2e-tests (test-e2e.yaml)  →  release (release.yaml)
+```
+
+`build.yaml` runs `npm ci && npx allow-scripts && npm run build:package` and
+caches `dist` + `build` under a run-scoped key; the later jobs restore that
+cache with `fail-on-cache-miss: true` rather than rebuilding. `check.yaml` runs
+unit and integration tests — note that its lint and format steps are currently
+commented out, so `npm run lint` is not enforced by CI. E2E runs on a
+`ubuntu-latest` + `macos-latest` matrix with `max-parallel: 1`. Integration and
+E2E jobs are skipped for PRs from forks, because they need org secrets.
+`codeql.yaml` scans the workflow files themselves on pushes touching
+`.github/workflows/**`.
+
+`release.yaml` runs only on pushes to `main` or `beta`. It fetches a GitHub
+token from HashiCorp Vault via JWT auth (no long-lived token in repo secrets),
+commits as `contentful-automation[bot]`, and runs `semantic-release`.
+`package.json` → `release` defines three branches: `main` (stable), `beta`
+(prerelease on the `beta` channel) and `exo` (prerelease on the `exo` channel).
+Plugins publish to npm and attach the three platform zips to the GitHub release.
+`releaseRules` add `build(deps)` → patch on top of the defaults, so dependency
+bumps ship as releases.
+
+## Things worth knowing before you change something
+
+- `yargs` is pinned to `~13.3.2` while upstream is several majors ahead. The
+  `commandDir` routing and `getContext().fullCommands` used by `getCommand`
+  are the pieces that would need rework to move off it.
+- `lib/` is roughly half TypeScript and half JavaScript (53 `.ts` / 67 `.js` at
+  the time of writing) with `allowJs: true`. That is a migration in progress,
+  not an accident.
+- `npm install` does not run lifecycle scripts (`.npmrc`), so husky hooks are
+  not installed until `npx allow-scripts` runs. See
+  [docs/ADRs/2026-08-25-disable-npm-install-scripts-by-default.md](./docs/ADRs/2026-08-25-disable-npm-install-scripts-by-default.md).
+- `catalog-info.yaml` still carries CircleCI annotations and the README a
+  CircleCI badge, but CI runs on GitHub Actions.

--- a/docs/ADRs/2026-08-25-disable-npm-install-scripts-by-default.md
+++ b/docs/ADRs/2026-08-25-disable-npm-install-scripts-by-default.md
@@ -1,0 +1,81 @@
+# Disable npm install scripts by default, re-enable them from an allowlist
+
+- **Date:** 2026-08-25
+- **Status:** Accepted (in effect since 2025-12-02)
+
+> This record was written on 2026-08-25 from the commit history. It documents an
+> existing decision rather than a new one; the rationale below is reconstructed
+> from the commits and the resulting configuration, not from a contemporaneous
+> design discussion.
+
+## Context
+
+`contentful-cli` installs a large dependency tree — at the time of writing, 41
+runtime dependencies and 40 dev dependencies, several of which (`contentful-export`,
+`contentful-import`, `contentful-migration`, `semantic-release`) pull in deep
+trees of their own. By default npm executes arbitrary `preinstall`/`install`/
+`postinstall` scripts from every package in that tree, on developer machines and
+in CI, including the CI job that holds a publish token.
+
+Only a small number of packages here actually need an install script: `husky`
+(installs the git hooks), a transitive `spawn-sync` under
+`inquirer-select-directory`, and later `esbuild` beneath `@yao-pkg/pkg` for the
+standalone binary build.
+
+Two commits put the current arrangement in place:
+
+- `f65855d8eb7f4cd50a2e32cadbb7bae39a95f240` — *chore: [] ignore npm scripts (#3172)*,
+  2025-11-26. Adds `.npmrc` containing `ignore-scripts=true`, and removes the
+  line that had been keeping `.npmrc` out of version control in `.gitignore`.
+- `d8998ec7345d7cebcae1c3203487fc79b3484688` — *chore: permissions updated (#3181)*,
+  2025-12-02. Adds `@lavamoat/allow-scripts` as a dev dependency and a
+  `lavamoat.allowScripts` block to `package.json`, and adds `npx allow-scripts`
+  after `npm ci` in `build.yaml`, `check.yaml`, `release.yaml` and
+  `test-e2e.yaml`. The same PR tightened the `permissions:` blocks on those
+  workflows.
+
+Blanket `ignore-scripts=true` on its own would have broken the husky hooks and
+the `pkg` build, so the allowlist is what makes the first commit workable.
+
+## Decision
+
+Install scripts are off globally via a committed `.npmrc`
+(`ignore-scripts=true`). The packages that genuinely need one are enumerated in
+`package.json` under `lavamoat.allowScripts` and run explicitly with
+`npx allow-scripts`, which is invoked as its own step after `npm ci` in every
+CI workflow.
+
+The current allowlist is:
+
+```json
+"lavamoat": {
+  "allowScripts": {
+    "$root$": true,
+    "husky": true,
+    "inquirer-select-directory>inquirer>external-editor>spawn-sync": true,
+    "@yao-pkg/pkg>esbuild": true
+  }
+}
+```
+
+Entries are written as full dependency paths, so allowing a package in one
+position does not allow it everywhere it appears in the tree.
+
+## Consequences
+
+- A plain `npm install` leaves husky's git hooks uninstalled. The `precommit`
+  and `prepush` scripts in `package.json` therefore do not fire until someone
+  runs `npx allow-scripts`. This is the most common surprise for a new
+  contributor or an automated agent working in the repo.
+- Adding a dependency that needs an install script is a two-part change:
+  the dependency, plus its full path in `lavamoat.allowScripts`. Without the
+  second part it silently does not run its script.
+- A dependency that starts requiring an install script after a version bump will
+  fail quietly rather than loudly. `@lavamoat/allow-scripts` reports packages
+  with scripts that are neither allowed nor explicitly denied, but nothing in
+  CI currently fails a build on that report.
+- CI gains a step that must be kept in the four workflows that install
+  dependencies. A new workflow that runs `npm ci` without `npx allow-scripts`
+  will not be able to run the standalone binary build.
+- In exchange, no third-party install script executes in the release job that
+  holds the npm publish credentials unless it has been explicitly listed here.

--- a/docs/ADRs/README.md
+++ b/docs/ADRs/README.md
@@ -1,0 +1,5 @@
+# Architectural Decision Records
+
+Records of decisions this repository has actually made, newest first.
+
+- [2026-08-25 — Disable npm install scripts by default, re-enable them from an allowlist](./2026-08-25-disable-npm-install-scripts-by-default.md) — why `.npmrc` sets `ignore-scripts=true` and CI runs `npx allow-scripts`.


### PR DESCRIPTION
Closes the three failing AI harness readiness controls for this repo (DX-1299, parent DX-1296).

## Controls

| Control | Before | After |
| --- | --- | --- |
| `agents-md-present` | missing | `AGENTS.md` (96 non-blank lines) |
| `architecture-md-present` | missing | `ARCHITECTURE.md` (147 non-blank lines) |
| `contributing-md-present` | already passing | untouched |
| `decision-records-present` | missing | `docs/ADRs/2026-08-25-disable-npm-install-scripts-by-default.md` (66 non-blank lines) |

## Files

- `AGENTS.md` — setup including the `npx allow-scripts` step that `.npmrc`'s `ignore-scripts=true` makes necessary, the real npm script table with the 80% `nyc` coverage gate, which test tiers need Contentful credentials and which do not, and how to add a command given that yargs `commandDir` makes file placement the routing table (including the `lib/config.js` `noAuthNeeded` / `noSpaceIdNeeded` step that is easy to miss).
- `ARCHITECTURE.md` — `bin/contentful.js` → `dist/lib/cli.js` entry point, command resolution and the three middlewares in `lib/utils/middlewares.js`, config resolution order in `lib/context.js`, the two CMA client factories in `lib/utils/contentful-clients.js`, the RxJS event system and its single consumer, the three test tiers with talkback replay from `recordings/`, and the dual npm + `@yao-pkg/pkg` build feeding the GitHub Actions → semantic-release pipeline.
- `docs/ADRs/2026-08-25-disable-npm-install-scripts-by-default.md` — the decision record.
- `docs/ADRs/README.md` — one-line index.

## ADR reconstruction disclosure

The ADR documents an **existing** decision and was written after the fact, on 2026-08-25, from the commit history. The record itself carries that disclosure in a blockquote at the top rather than presenting itself as contemporaneous. It is evidenced by two commits:

- f65855d8eb7f4cd50a2e32cadbb7bae39a95f240 — adds `.npmrc` with `ignore-scripts=true` (#3172)
- d8998ec7345d7cebcae1c3203487fc79b3484688 — adds `@lavamoat/allow-scripts`, the `lavamoat.allowScripts` block, and `npx allow-scripts` to the four workflows (#3181)

No rationale beyond what those commits and the resulting config support is asserted.

## Notes for reviewers

Two things I documented as-is rather than fixing, since this is a docs-only change:

- The lint and format steps in `.github/workflows/check.yaml` are commented out, so `npm run lint` is not currently enforced by CI. `ARCHITECTURE.md` says so.
- `catalog-info.yaml` still carries CircleCI annotations and the README a CircleCI badge, but CI runs on GitHub Actions. Also noted.

Docs-only: no installs, builds, or test suites were run.