### PR TITLE
feat: add opt-in bulk entry operations to space import

### DIFF
--- a/docs/ADRs/2026-09-05-bulk-entry-operations-space-import-poc.md
+++ b/docs/ADRs/2026-09-05-bulk-entry-operations-space-import-poc.md
@@ -1,0 +1,180 @@
+# Use an opt-in hybrid path for bulk entry imports
+
+- **Date:** 2026-09-05
+- **Status:** Proposed (proof of concept)
+- **Issue:** [#3331](https://github.com/contentful/contentful-cli/issues/3331)
+
+## Context
+
+`contentful space import` delegates to `contentful-import`. That importer uses
+the classic Content Management API workflow, which creates, updates and
+publishes entries individually. The request rate makes restoring exports with
+100,000 or more entries prohibitively slow.
+
+Contentful's Bulk Entry Operations API can create or update up to 10,000 entries
+in one asynchronous job. The existing Bulk Actions API can publish up to 200
+entities in one asynchronous action. These APIs can substantially reduce the
+number of requests needed for the entry portion of a restore, but they do not
+replace the complete import workflow:
+
+- content models, locales, tags, editor interfaces and assets still need the
+  existing importer;
+- create and update use different bulk endpoints and update payloads require the
+  current destination version;
+- publication state must be reconstructed from the export;
+- Bulk Entry Operations requires the Bulk Content Operations entitlement;
+- at most one Bulk Entry Operation may be in flight per space;
+- Bulk Actions and locale-based publishing have separate behavior and limits.
+
+Environment cloning is not an alternative for this use case. A restore may come
+from a historical JSON backup after the source environment has been deleted, or
+the JSON may have been transformed to repair cross-space resource links.
+
+## Decision
+
+Add an explicit `--use-bulk-entries` option to `contentful space import`. The
+option defaults to `false`; the established import path remains unchanged unless
+the caller opts in.
+
+When the option is enabled, the command uses a hybrid, two-phase import:
+
+1. Read the export JSON and pass a copy with `entries: []` to
+   `contentful-import`. This imports content models, locales, tags, editor
+   interfaces and assets using the existing implementation.
+2. Import the original `entries` array through a dedicated bulk transport built
+   on the repository's `createPlainClient` wrapper.
+
+The bulk entry phase makes the following choices.
+
+### Create and update partitioning
+
+List destination entry IDs and versions before writing. An entry absent from the
+destination is sent to `bulk_operations/entries/create`; an existing entry is
+sent to `bulk_operations/entries/update` with the destination's current
+`sys.version`.
+
+Source environment metadata is not copied. Bulk payloads retain the entry ID,
+content type link, fields and metadata. Every imported entry must have a
+`sys.id`, because preserving IDs is required for links and for later selective
+publishing.
+
+`--skip-content-updates` removes existing entries from the update set while
+still allowing new entries to be created.
+
+### Uploads and job execution
+
+Serialize each batch as a JSON array and upload it through the environment-scoped
+Upload API using `application/octet-stream`. Each create or update batch contains
+at most 10,000 entries.
+
+Run jobs sequentially. This follows the platform restriction that only one Bulk
+Entry Operation may be active in a space at a time and avoids adding a separate
+conflict/retry scheduler to the PoC.
+
+Poll every asynchronous operation until it completes, fails or reaches the
+configured timeout. Inspect `result.items` after a completed job because a job
+may complete while individual entries fail.
+
+### Publication
+
+An entry is selected for publication only when the export contains a numeric
+`sys.publishedVersion`. Draft entries are imported but remain unpublished.
+`--skip-content-publishing` disables this phase.
+
+Publish selected entries through Bulk Actions in batches of at most 200. Bulk
+Entry Operation results identify successful entries but do not guarantee a
+returned version. The PoC therefore derives the post-write version as follows:
+
+- create: version `1`;
+- update: destination version plus `1`;
+- if the operation result provides a version, use that value instead.
+
+Only entries successfully written by this invocation are eligible for
+publication.
+
+### Entitlement and failure behavior
+
+Do not silently fall back to classic entry import when the bulk endpoint returns
+`403`. Report that Bulk Content Operations is required. A silent fallback would
+make a command chosen for predictable restore performance unexpectedly return to
+the slow path.
+
+This means the import is not transactional. The classic phase may have imported
+content models and other entities before the bulk phase discovers a missing
+entitlement or another failure. Re-running the command is expected to reconcile
+existing entities through normal create-versus-update partitioning.
+
+`--content-model-only` bypasses the bulk path entirely. Existing options retain
+their established meaning.
+
+## Alternatives considered
+
+### Replace the classic importer completely
+
+Rejected for the PoC. Bulk Entry Operations only addresses entries; rebuilding
+locale, content model, editor interface, tag and asset behavior would duplicate
+`contentful-import` and increase compatibility risk.
+
+### Enable bulk operations automatically
+
+Rejected. Availability depends on a Premium entitlement, and changing the
+default would break imports for spaces without it. Opt-in behavior also limits
+the blast radius while the API integration is evaluated.
+
+### Fall back automatically after a `403`
+
+Rejected. The classic phase has already run at that point, and silently importing
+entries one by one could take hours on the large restores this option targets.
+An actionable failure is more predictable.
+
+### Implement the optimization only in `contentful-import`
+
+Deferred. That may be the better long-term ownership boundary because other
+consumers would benefit, but a CLI-level PoC can validate API compatibility and
+operational behavior without first changing the sibling package.
+
+### Use environment cloning
+
+Rejected for backup restore and transformed cross-space imports, where no live
+source environment exists or the payload must be rewritten before import.
+
+## Consequences
+
+- Large entry restores can reduce CMA request volume by several orders of
+  magnitude when the space has Bulk Content Operations enabled.
+- Users must explicitly choose `--use-bulk-entries` and must verify entitlement
+  before relying on it for a restore.
+- Non-entry entities retain the mature behavior of `contentful-import`.
+- The command performs an additional destination-wide entry listing to decide
+  between create and update.
+- Create and update jobs are serialized, favoring API compatibility over maximum
+  concurrency.
+- Partial imports remain possible. There is no rollback across the classic and
+  bulk phases or across individual bulk jobs.
+- Publishing restores entry-level published versus draft state, but locale-based
+  publishing remains a separate problem and is outside this PoC.
+- Assets and archived entries are not moved to a new bulk implementation.
+- The CLI now owns orchestration logic that may eventually belong in
+  `contentful-import`.
+
+## Validation and graduation criteria
+
+The PoC includes unit coverage for batching, payload preparation, destination
+version partitioning, polling, item-level failures, raw and SDK transport paths,
+entitlement errors and selective publication. The new helper and all executable
+lines added by the change have 100% statement, branch and function coverage. The
+TypeScript build and standalone macOS, Linux and Windows packaging complete
+successfully.
+
+A real import against a space without Bulk Content Operations confirmed the
+expected `403` entitlement response after the classic phase. Before changing the
+option from opt-in or marking this decision Accepted, validate against an
+entitled space with representative data and confirm:
+
+- create and update jobs at multiple batch boundaries;
+- circular and cross-space links;
+- partial item failures and safe reruns;
+- published and draft entries, including locale-based publishing expectations;
+- large exports under upload-size and timeout limits;
+- operational guidance for detecting entitlement before starting the classic
+  phase, or an API-supported preflight check.

--- a/docs/ADRs/README.md
+++ b/docs/ADRs/README.md
@@ -2,4 +2,5 @@
 
 Records of decisions this repository has actually made, newest first.
 
+- [2026-09-05 — Use an opt-in hybrid path for bulk entry imports](./2026-09-05-bulk-entry-operations-space-import-poc.md) — why the PoC keeps non-entry imports on `contentful-import`, batches entry writes and publishing separately, and fails explicitly when the Premium entitlement is unavailable.
 - [2026-08-25 — Disable npm install scripts by default, re-enable them from an allowlist](./2026-08-25-disable-npm-install-scripts-by-default.md) — why `.npmrc` sets `ignore-scripts=true` and CI runs `npx allow-scripts`.

--- a/docs/space/import/README.md
+++ b/docs/space/import/README.md
@@ -20,6 +20,12 @@ Options:
   --skip-locales             Skip importing locales   [boolean] [default: false]
   --skip-content-publishing  Skips content publishing. Creates content but does
                              not publish it           [boolean] [default: false]
+  --use-bulk-entries         Import entries via Bulk Entry Operations
+                             (create/update, up to 10k per job) and Bulk Actions
+                             for publish. Requires Bulk Content Operations
+                             (Premium). Content model, locales, tags and assets
+                             still use the classic importer.
+                                                      [boolean] [default: false]
   --skip-content-updates     Skips updating existing content, only creates new
                              entries.                 [boolean] [default: false]
   --skip-asset-updates       Skips updating existing assets, only creates new
@@ -50,6 +56,24 @@ Options:
 contentful space import \
   --content-file exported-file.json \
 ```
+
+### Large restores with Bulk Entry Operations
+
+Classic import creates, updates and publishes entries one CMA request at a time. For large backups (tens or hundreds of thousands of entries) you can opt into [Bulk Entry Operations](https://www.contentful.com/developers/docs/references/content-management-api/bulk-entry-content-operations/) and [Bulk Actions](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/bulk-actions) for the entry payload:
+
+```sh
+contentful space import \
+  --content-file exported-file.json \
+  --use-bulk-entries
+```
+
+This keeps the existing importer for content types, locales, editor interfaces, tags and assets, then:
+
+1. Splits entries into create vs update against the destination environment
+2. Uploads JSON batches of up to 10,000 entries and runs `bulk_operations/entries/create` / `update`
+3. Publishes only entries that were published in the export (`sys.publishedVersion`), in Bulk Action batches of 200
+
+`--skip-content-publishing`, `--skip-content-updates`, `--content-model-only` and the other import flags keep their existing meaning. Bulk Entry Operations is a Premium feature; if the destination space is not entitled the command fails with a clear error rather than silently falling back.
 
 ## Limitations
 

--- a/lib/cmds/space_cmds/import.ts
+++ b/lib/cmds/space_cmds/import.ts
@@ -1,10 +1,17 @@
 import runContentfulImport from 'contentful-import'
 import { handleAsyncError as handle } from '../../utils/async'
+import {
+  createCmaBulkTransport,
+  importEntriesWithBulkOperations,
+  SourceEntry
+} from '../../utils/bulk-entry-import'
+import { createPlainClient } from '../../utils/contentful-clients'
+import { copyright } from '../../utils/copyright'
+import { getPath, readFileP } from '../../utils/fs'
+import { getHeadersFromOption } from '../../utils/headers'
+import { warning } from '../../utils/log'
 import { proxyObjectToString } from '../../utils/proxy'
 import { version } from '../../../package.json'
-import { warning } from '../../utils/log'
-import { getHeadersFromOption } from '../../utils/headers'
-import { copyright } from '../../utils/copyright'
 import { Argv } from 'yargs'
 
 export const command = 'import'
@@ -54,6 +61,12 @@ export const builder = (yargs: Argv) => {
       type: 'boolean',
       default: false
     })
+    .option('use-bulk-entries', {
+      describe:
+        'Import entries via Bulk Entry Operations (create/update, up to 10k per job) and Bulk Actions for publish. Requires Bulk Content Operations (Premium). Content model, locales, tags and assets still use the classic importer.',
+      type: 'boolean',
+      default: false
+    })
     .option('skip-content-updates', {
       describe: 'Skips updating existing content, only creates new entries.',
       type: 'boolean',
@@ -65,7 +78,8 @@ export const builder = (yargs: Argv) => {
       default: false
     })
     .option('include-experience-orchestration', {
-      describe: 'Import Experience Orchestration entities (designTokens, components, experienceTemplates, experienceFragments, dataAssemblies, experiences). Requires a space with ExO enabled.',
+      describe:
+        'Import Experience Orchestration entities (designTokens, components, experienceTemplates, experienceFragments, dataAssemblies, experiences). Requires a space with ExO enabled.',
       type: 'boolean',
       default: true
     })
@@ -136,13 +150,23 @@ interface Context {
   rawProxy?: string
 }
 
+interface ImportContent {
+  entries?: SourceEntry[]
+  [key: string]: unknown
+}
+
 interface ImportSpaceProps {
   context: Context
   feature?: string
   update?: never
   header?: string
   proxy?: string
-  content?: object
+  content?: ImportContent
+  contentFile?: string
+  contentModelOnly?: boolean
+  skipContentPublishing?: boolean
+  skipContentUpdates?: boolean
+  useBulkEntries?: boolean
   uploadAssets?: string
   assetsDirectory?: string
   includeExperienceOrchestration?: boolean
@@ -155,12 +179,29 @@ interface Options {
   managementFeature: string
   managementToken?: string
   host?: string
-  headers: string
+  headers: Record<string, string>
   proxy?: string
   rawProxy?: string
   uploadAssets?: string
   assetsDirectory?: string
   includeExperienceOrchestration?: boolean
+  content?: ImportContent
+  contentFile?: string
+}
+
+async function loadImportContent(
+  argv: ImportSpaceProps
+): Promise<ImportContent> {
+  if (argv.content) {
+    return argv.content
+  }
+
+  if (!argv.contentFile) {
+    throw new Error('The --content-file option is required.')
+  }
+
+  const raw = await readFileP(getPath(argv.contentFile), 'utf8')
+  return JSON.parse(raw as string)
 }
 
 export const importSpace = async (argv: ImportSpaceProps) => {
@@ -173,7 +214,11 @@ export const importSpace = async (argv: ImportSpaceProps) => {
     feature = 'space-import',
     uploadAssets,
     assetsDirectory,
-    includeExperienceOrchestration
+    includeExperienceOrchestration,
+    useBulkEntries,
+    contentModelOnly,
+    skipContentPublishing,
+    skipContentUpdates
   } = argv
   const {
     managementToken,
@@ -203,6 +248,7 @@ export const importSpace = async (argv: ImportSpaceProps) => {
     assetsDirectory,
     includeExperienceOrchestration
   }
+  delete (options as Options & { useBulkEntries?: boolean }).useBulkEntries
 
   if (proxy) {
     // contentful-import and contentful-export
@@ -217,7 +263,56 @@ export const importSpace = async (argv: ImportSpaceProps) => {
     options.rawProxy = rawProxy
   }
 
-  return runContentfulImport(options)
+  const shouldUseBulkEntries = Boolean(useBulkEntries) && !contentModelOnly
+
+  if (!shouldUseBulkEntries) {
+    return runContentfulImport(options)
+  }
+
+  if (!activeSpaceId) {
+    throw new Error('A destination space ID is required for bulk entry import.')
+  }
+
+  const source = await loadImportContent(argv)
+  const entries = Array.isArray(source.entries) ? source.entries : []
+  const contentWithoutEntries = { ...source, entries: [] }
+
+  const importResult = await runContentfulImport({
+    ...options,
+    content: contentWithoutEntries,
+    contentFile: undefined
+  })
+
+  if (entries.length === 0) {
+    return importResult
+  }
+
+  const environmentId = activeEnvironmentId || 'master'
+  const client = await createPlainClient(
+    {
+      accessToken: managementToken,
+      feature,
+      headers: getHeadersFromOption(argv.header),
+      host
+    },
+    {
+      spaceId: activeSpaceId,
+      environmentId
+    }
+  )
+
+  await importEntriesWithBulkOperations({
+    entries,
+    skipContentPublishing,
+    skipContentUpdates,
+    transport: createCmaBulkTransport({
+      client,
+      spaceId: activeSpaceId,
+      environmentId
+    })
+  })
+
+  return importResult
 }
 
 export const handler = handle(importSpace)

--- a/lib/utils/bulk-entry-import.ts
+++ b/lib/utils/bulk-entry-import.ts
@@ -1,0 +1,638 @@
+import { log as defaultLog, warning as defaultWarning } from './log'
+import type { PlainClientAPI } from 'contentful-management'
+
+export const MAX_ENTRIES_PER_BULK_JOB = 10_000
+export const MAX_ENTITIES_PER_BULK_ACTION = 200
+
+export type BulkOperationAction = 'create' | 'update'
+
+export interface SourceEntry {
+  sys?: {
+    id?: string
+    type?: string
+    version?: number
+    publishedVersion?: number
+    contentType?: {
+      sys?: {
+        id?: string
+        type?: string
+        linkType?: string
+      }
+    }
+    [key: string]: unknown
+  }
+  fields?: Record<string, unknown>
+  metadata?: unknown
+}
+
+export interface BulkOperationEntityResult {
+  status?: string
+  entity?: {
+    sys?: {
+      id?: string
+      version?: number
+    }
+  }
+  error?: {
+    message?: string
+    sys?: { id?: string }
+  }
+}
+
+export interface BulkOperation {
+  sys?: {
+    id?: string
+    status?: string
+  }
+  result?: {
+    items?: BulkOperationEntityResult[]
+  }
+}
+
+export interface BulkEntryImportLogger {
+  log: (...args: unknown[]) => void
+  warning: (...args: unknown[]) => void
+}
+
+interface BulkWaitOptions {
+  sleep: (ms: number) => Promise<void>
+  pollIntervalMs: number
+  pollTimeoutMs: number
+}
+
+export interface BulkEntryImportTransport {
+  listEntryVersions: () => Promise<Map<string, number>>
+  uploadEntries: (entries: unknown[]) => Promise<string>
+  createBulkOperation: (
+    action: BulkOperationAction,
+    uploadId: string
+  ) => Promise<BulkOperation>
+  getBulkOperation: (id: string) => Promise<BulkOperation>
+  publishEntries: (
+    items: Array<{ id: string; version: number }>,
+    waitOptions: BulkWaitOptions
+  ) => Promise<void>
+}
+
+export interface BulkEntryImportOptions {
+  entries: SourceEntry[]
+  transport: BulkEntryImportTransport
+  skipContentUpdates?: boolean
+  skipContentPublishing?: boolean
+  logger?: BulkEntryImportLogger
+  sleep?: (ms: number) => Promise<void>
+  pollIntervalMs?: number
+  pollTimeoutMs?: number
+}
+
+export class BulkEntryImportError extends Error {
+  failures: string[]
+
+  constructor(message: string, failures: string[] = []) {
+    super(message)
+    this.name = 'BulkEntryImportError'
+    this.failures = failures
+  }
+}
+
+function httpStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') {
+    return undefined
+  }
+
+  const withResponse = error as {
+    response?: { status?: number }
+    status?: number
+    message?: string
+    name?: string
+  }
+  const status = withResponse.response?.status ?? withResponse.status
+  if (status !== undefined) {
+    return status
+  }
+
+  if (withResponse.message) {
+    try {
+      const parsed = JSON.parse(withResponse.message) as { status?: number }
+      if (parsed.status !== undefined) {
+        return parsed.status
+      }
+    } catch {
+      // The message is not a serialized CMA error.
+    }
+  }
+
+  const statusFromName = Number.parseInt(withResponse.name || '', 10)
+  return Number.isNaN(statusFromName) ? undefined : statusFromName
+}
+
+export function chunk<T>(items: T[], size: number): T[][] {
+  if (size <= 0) {
+    throw new Error('Chunk size must be greater than 0')
+  }
+
+  const chunks: T[][] = []
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size))
+  }
+  return chunks
+}
+
+export function isPublishedInExport(entry: SourceEntry): boolean {
+  return typeof entry.sys?.publishedVersion === 'number'
+}
+
+export function prepareEntryForCreate(entry: SourceEntry): SourceEntry {
+  return prepareEntry(entry)
+}
+
+export function prepareEntryForUpdate(
+  entry: SourceEntry,
+  version: number
+): SourceEntry {
+  return prepareEntry(entry, version)
+}
+
+function prepareEntry(entry: SourceEntry, version?: number): SourceEntry {
+  const sys: SourceEntry['sys'] = { type: 'Entry' }
+
+  if (entry.sys?.id) {
+    sys.id = entry.sys.id
+  }
+
+  if (entry.sys?.contentType) {
+    sys.contentType = entry.sys.contentType
+  }
+
+  if (typeof version === 'number') {
+    sys.version = version
+  }
+
+  const prepared: SourceEntry = { sys, fields: entry.fields || {} }
+
+  if (entry.metadata !== undefined) {
+    prepared.metadata = entry.metadata
+  }
+
+  return prepared
+}
+
+export function partitionEntries(
+  entries: SourceEntry[],
+  destinationVersions: Map<string, number>,
+  skipContentUpdates = false
+): { toCreate: SourceEntry[]; toUpdate: SourceEntry[] } {
+  const toCreate: SourceEntry[] = []
+  const toUpdate: SourceEntry[] = []
+
+  for (const [index, entry] of entries.entries()) {
+    const id = entry.sys?.id
+    if (!id) {
+      throw new BulkEntryImportError(
+        `Entry at index ${index} does not include sys.id`
+      )
+    }
+
+    if (destinationVersions.has(id)) {
+      if (!skipContentUpdates) {
+        toUpdate.push(
+          prepareEntryForUpdate(entry, destinationVersions.get(id) as number)
+        )
+      }
+      continue
+    }
+
+    toCreate.push(prepareEntryForCreate(entry))
+  }
+
+  return { toCreate, toUpdate }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function unwrapRaw<T>(response: T | { data: T }): T {
+  if (response && typeof response === 'object' && 'data' in response) {
+    return (response as { data: T }).data
+  }
+  return response as T
+}
+
+function operationStatus(operation: BulkOperation): string {
+  return (operation.sys?.status || '').toLowerCase()
+}
+
+function isTerminalSuccess(status: string): boolean {
+  return status === 'completed' || status === 'succeeded'
+}
+
+function isTerminalFailure(status: string): boolean {
+  return status === 'failed' || status === 'cancelled' || status === 'canceled'
+}
+
+async function waitForBulkOperation(
+  transport: BulkEntryImportTransport,
+  operation: BulkOperation,
+  options: {
+    sleep: (ms: number) => Promise<void>
+    pollIntervalMs: number
+    pollTimeoutMs: number
+    action: BulkOperationAction
+  }
+): Promise<BulkOperation> {
+  const id = operation.sys?.id
+  if (!id) {
+    throw new BulkEntryImportError(
+      `Bulk ${options.action} operation response did not include an id`
+    )
+  }
+
+  const startedAt = Date.now()
+  let current = operation
+
+  while (!isTerminalSuccess(operationStatus(current))) {
+    if (isTerminalFailure(operationStatus(current))) {
+      throw new BulkEntryImportError(
+        `Bulk ${options.action} operation ${id} ${operationStatus(current)}`
+      )
+    }
+
+    if (Date.now() - startedAt > options.pollTimeoutMs) {
+      throw new BulkEntryImportError(
+        `Timed out waiting for bulk ${options.action} operation ${id}`
+      )
+    }
+
+    await options.sleep(options.pollIntervalMs)
+    current = await transport.getBulkOperation(id)
+  }
+
+  return current
+}
+
+function collectItemOutcomes(
+  operation: BulkOperation,
+  submittedEntries: SourceEntry[],
+  versions: Map<string, number>,
+  failures: string[]
+): void {
+  const items = operation.result?.items || []
+  const submittedVersions = new Map(
+    submittedEntries.map(
+      entry => [entry.sys?.id as string, (entry.sys?.version || 0) + 1] as const
+    )
+  )
+
+  for (const [index, item] of items.entries()) {
+    const id = item.entity?.sys?.id || submittedEntries[index]?.sys?.id
+    const status = (item.status || '').toLowerCase()
+
+    if (status === 'failed') {
+      const message =
+        item.error?.message || item.error?.sys?.id || 'unknown error'
+      failures.push(id ? `${id}: ${message}` : message)
+      continue
+    }
+
+    if (id) {
+      const version = item.entity?.sys?.version ?? submittedVersions.get(id)
+      if (typeof version === 'number') {
+        versions.set(id, version)
+      }
+    }
+  }
+}
+
+async function runBulkJobs(
+  action: BulkOperationAction,
+  entries: SourceEntry[],
+  transport: BulkEntryImportTransport,
+  versions: Map<string, number>,
+  failures: string[],
+  logger: BulkEntryImportLogger,
+  waitOptions: {
+    sleep: (ms: number) => Promise<void>
+    pollIntervalMs: number
+    pollTimeoutMs: number
+  }
+): Promise<void> {
+  if (entries.length === 0) {
+    return
+  }
+
+  const batches = chunk(entries, MAX_ENTRIES_PER_BULK_JOB)
+  logger.log(
+    `Bulk ${action}: ${entries.length} entries in ${batches.length} job(s)`
+  )
+
+  for (const [index, batch] of batches.entries()) {
+    logger.log(
+      `Uploading bulk ${action} batch ${index + 1}/${batches.length} (${
+        batch.length
+      } entries)`
+    )
+    const uploadId = await transport.uploadEntries(batch)
+    const started = await transport.createBulkOperation(action, uploadId)
+    const completed = await waitForBulkOperation(transport, started, {
+      ...waitOptions,
+      action
+    })
+    collectItemOutcomes(completed, batch, versions, failures)
+  }
+}
+
+export async function importEntriesWithBulkOperations({
+  entries,
+  transport,
+  skipContentUpdates = false,
+  skipContentPublishing = false,
+  logger = { log: defaultLog, warning: defaultWarning },
+  sleep = defaultSleep,
+  pollIntervalMs = 2000,
+  pollTimeoutMs = 60 * 60 * 1000
+}: BulkEntryImportOptions): Promise<{
+  created: number
+  updated: number
+  published: number
+  failures: string[]
+}> {
+  if (entries.length === 0) {
+    logger.log('No entries to import via bulk operations')
+    return { created: 0, updated: 0, published: 0, failures: [] }
+  }
+
+  const destinationVersions = await transport.listEntryVersions()
+  const { toCreate, toUpdate } = partitionEntries(
+    entries,
+    destinationVersions,
+    skipContentUpdates
+  )
+  const versions = new Map(destinationVersions)
+  const failures: string[] = []
+  const waitOptions = { sleep, pollIntervalMs, pollTimeoutMs }
+
+  await runBulkJobs(
+    'create',
+    toCreate,
+    transport,
+    versions,
+    failures,
+    logger,
+    waitOptions
+  )
+  await runBulkJobs(
+    'update',
+    toUpdate,
+    transport,
+    versions,
+    failures,
+    logger,
+    waitOptions
+  )
+
+  const writtenIds = new Set(
+    [...toCreate, ...toUpdate]
+      .map(entry => entry.sys?.id)
+      .filter((id): id is string => Boolean(id))
+      .filter(id => !failures.some(failure => failure.startsWith(`${id}:`)))
+  )
+
+  for (const entry of toCreate) {
+    const id = entry.sys?.id
+    if (id && writtenIds.has(id) && !versions.has(id)) {
+      versions.set(id, 1)
+    }
+  }
+
+  let published = 0
+  if (!skipContentPublishing) {
+    const toPublish = entries
+      .filter(isPublishedInExport)
+      .map(entry => entry.sys?.id)
+      .filter((id): id is string => Boolean(id && writtenIds.has(id)))
+      .map(id => ({ id, version: versions.get(id) }))
+      .filter(
+        (item): item is { id: string; version: number } =>
+          typeof item.version === 'number'
+      )
+
+    const publishBatches = chunk(toPublish, MAX_ENTITIES_PER_BULK_ACTION)
+    if (toPublish.length > 0) {
+      logger.log(
+        `Bulk publish: ${toPublish.length} entries in ${publishBatches.length} action(s)`
+      )
+    }
+
+    for (const batch of publishBatches) {
+      await transport.publishEntries(batch, waitOptions)
+      published += batch.length
+    }
+  }
+
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      logger.warning(`Bulk entry operation failed for ${failure}`)
+    }
+    throw new BulkEntryImportError(
+      `Bulk entry import finished with ${failures.length} failed item(s)`,
+      failures
+    )
+  }
+
+  logger.log(
+    `Finished bulk entry import (${toCreate.length} created, ${toUpdate.length} updated, ${published} published)`
+  )
+
+  return {
+    created: toCreate.length,
+    updated: toUpdate.length,
+    published,
+    failures
+  }
+}
+
+export function createCmaBulkTransport({
+  client,
+  spaceId,
+  environmentId
+}: {
+  client: PlainClientAPI
+  spaceId: string
+  environmentId: string
+}): BulkEntryImportTransport {
+  const environmentPath = `/spaces/${spaceId}/environments/${environmentId}`
+
+  return {
+    async listEntryVersions() {
+      const versions = new Map<string, number>()
+      let skip = 0
+      const limit = 1000
+
+      let hasMore = true
+      while (hasMore) {
+        let page: {
+          items?: Array<{ sys?: { id?: string; version?: number } }>
+          total?: number
+        }
+
+        if (client.entry?.getMany) {
+          page = await client.entry.getMany({
+            spaceId,
+            environmentId,
+            query: {
+              skip,
+              limit,
+              select: 'sys.id,sys.version'
+            }
+          })
+        } else {
+          page = unwrapRaw(
+            await client.raw.get(
+              `${environmentPath}/entries?skip=${skip}&limit=${limit}&select=sys.id,sys.version`
+            )
+          ) as {
+            items?: Array<{ sys?: { id?: string; version?: number } }>
+            total?: number
+          }
+        }
+
+        for (const item of page.items || []) {
+          if (item.sys?.id && typeof item.sys.version === 'number') {
+            versions.set(item.sys.id, item.sys.version)
+          }
+        }
+
+        const total = page.total ?? (page.items || []).length
+        skip += limit
+        hasMore = skip < total && (page.items || []).length > 0
+      }
+
+      return versions
+    },
+
+    async uploadEntries(entries) {
+      const encoded = Buffer.from(JSON.stringify(entries))
+      const file = encoded.buffer.slice(
+        encoded.byteOffset,
+        encoded.byteOffset + encoded.byteLength
+      ) as ArrayBuffer
+
+      if (client.upload?.create) {
+        const upload = await client.upload.create(
+          { spaceId, environmentId },
+          { file }
+        )
+        const id = upload.sys?.id
+        if (!id) {
+          throw new BulkEntryImportError('Upload API did not return an id')
+        }
+        return id
+      }
+
+      const upload = unwrapRaw(
+        await client.raw.post(`${environmentPath}/uploads`, file, {
+          headers: { 'Content-Type': 'application/octet-stream' }
+        })
+      ) as { sys?: { id?: string } }
+      const id = upload.sys?.id
+      if (!id) {
+        throw new BulkEntryImportError('Upload API did not return an id')
+      }
+      return id
+    },
+
+    async createBulkOperation(action, uploadId) {
+      try {
+        return unwrapRaw(
+          await client.raw.post(
+            `${environmentPath}/bulk_operations/entries/${action}`,
+            {
+              upload: {
+                sys: {
+                  type: 'Upload',
+                  id: uploadId
+                }
+              }
+            }
+          )
+        ) as BulkOperation
+      } catch (error) {
+        if (httpStatus(error) === 403) {
+          throw new BulkEntryImportError(
+            'Bulk Entry Operations are not available for this space. This feature requires Bulk Content Operations (Premium). See https://www.contentful.com/developers/docs/references/content-management-api/bulk-entry-content-operations/'
+          )
+        }
+        throw error
+      }
+    },
+
+    async getBulkOperation(id) {
+      return unwrapRaw(
+        await client.raw.get(`${environmentPath}/bulk_operations/${id}`)
+      ) as BulkOperation
+    },
+
+    async publishEntries(items, waitOptions) {
+      const payload = {
+        entities: {
+          sys: { type: 'Array' as const },
+          items: items.map(({ id, version }) => ({
+            sys: {
+              type: 'Link' as const,
+              linkType: 'Entry' as const,
+              id,
+              version
+            }
+          }))
+        }
+      }
+
+      let action: { sys?: { id?: string; status?: string } }
+      if (client.bulkAction?.publish) {
+        action = await client.bulkAction.publish(
+          { spaceId, environmentId },
+          payload
+        )
+      } else {
+        action = unwrapRaw<{ sys?: { id?: string; status?: string } }>(
+          await client.raw.post(
+            `${environmentPath}/bulk_actions/publish`,
+            payload
+          )
+        )
+      }
+
+      const actionId = action.sys?.id
+      if (!actionId) {
+        throw new BulkEntryImportError('Bulk publish did not return an id')
+      }
+
+      const startedAt = Date.now()
+      while (!isTerminalSuccess((action.sys?.status || '').toLowerCase())) {
+        if (isTerminalFailure((action.sys?.status || '').toLowerCase())) {
+          throw new BulkEntryImportError(`Bulk publish ${actionId} failed`)
+        }
+        if (Date.now() - startedAt > waitOptions.pollTimeoutMs) {
+          throw new BulkEntryImportError(
+            `Timed out waiting for bulk publish ${actionId}`
+          )
+        }
+        await waitOptions.sleep(waitOptions.pollIntervalMs)
+        if (client.bulkAction?.get) {
+          action = await client.bulkAction.get({
+            spaceId,
+            environmentId,
+            bulkActionId: actionId
+          })
+        } else {
+          action = unwrapRaw<{ sys?: { id?: string; status?: string } }>(
+            await client.raw.get(
+              `${environmentPath}/bulk_actions/actions/${actionId}`
+            )
+          )
+        }
+      }
+    }
+  }
+}

--- a/test/integration/cmds/space/__snapshots__/import.test.js.snap
+++ b/test/integration/cmds/space/__snapshots__/import.test.js.snap
@@ -20,6 +20,13 @@ Options:
   --skip-content-publishing           Skips content publishing. Creates content
                                       but does not publish it
                                                       [boolean] [default: false]
+  --use-bulk-entries                  Import entries via Bulk Entry Operations
+                                      (create/update, up to 10k per job) and
+                                      Bulk Actions for publish. Requires Bulk
+                                      Content Operations (Premium). Content
+                                      model, locales, tags and assets still use
+                                      the classic importer.
+                                                      [boolean] [default: false]
   --skip-content-updates              Skips updating existing content, only
                                       creates new entries.
                                                       [boolean] [default: false]
@@ -78,6 +85,13 @@ Options:
                                                       [boolean] [default: false]
   --skip-content-publishing           Skips content publishing. Creates content
                                       but does not publish it
+                                                      [boolean] [default: false]
+  --use-bulk-entries                  Import entries via Bulk Entry Operations
+                                      (create/update, up to 10k per job) and
+                                      Bulk Actions for publish. Requires Bulk
+                                      Content Operations (Premium). Content
+                                      model, locales, tags and assets still use
+                                      the classic importer.
                                                       [boolean] [default: false]
   --skip-content-updates              Skips updating existing content, only
                                       creates new entries.

--- a/test/unit/cmds/space_cmds/import.test.ts
+++ b/test/unit/cmds/space_cmds/import.test.ts
@@ -1,35 +1,78 @@
-import { importSpace } from '../../../../lib/cmds/space_cmds/import'
+import { builder, importSpace } from '../../../../lib/cmds/space_cmds/import'
 
 import { version } from '../../../../package.json'
 import { getContext } from '../../../../lib/context'
 import contentfulImport from 'contentful-import'
+import { createPlainClient } from '../../../../lib/utils/contentful-clients'
+import { importEntriesWithBulkOperations } from '../../../../lib/utils/bulk-entry-import'
+import { getPath, readFileP } from '../../../../lib/utils/fs'
 
 jest.mock('../../../../lib/context')
 jest.mock('contentful-import')
+jest.mock('../../../../lib/utils/contentful-clients')
+jest.mock('../../../../lib/utils/fs')
+jest.mock('../../../../lib/utils/bulk-entry-import', () => {
+  const actual = jest.requireActual('../../../../lib/utils/bulk-entry-import')
+  return {
+    ...actual,
+    importEntriesWithBulkOperations: jest.fn().mockResolvedValue({
+      created: 1,
+      updated: 0,
+      published: 1,
+      failures: []
+    }),
+    createCmaBulkTransport: jest.fn().mockReturnValue({ mocked: true })
+  }
+})
 
 const mocks = {
-  getContext: getContext as jest.MockedFunction<any>
+  getContext: getContext as jest.MockedFunction<typeof getContext>,
+  getPath: getPath as jest.MockedFunction<typeof getPath>,
+  readFileP: readFileP as jest.MockedFunction<typeof readFileP>
 }
 
 mocks.getContext.mockResolvedValue({ managementToken: 'managementToken' })
 
-test('it should pass all args to contentful-import', async () => {
-  const stubArgv = {
-    context: {
-      activeSpaceId: 'spaceId',
-      managementToken: 'managementToken'
-    },
-    skipContentModel: false,
-    skipLocales: false,
-    host: 'api.contentful.com',
-    skipContentPublishing: false,
-    skipContentUpdates: true,
-    skipAssetUpdates: true,
-    managementApplication: `contentful.cli/${version}`,
-    managementFeature: 'space-import',
-    uploadAssets: true,
-    assetsDirectory: 'assets'
+beforeEach(() => {
+  jest.clearAllMocks()
+  mocks.getContext.mockResolvedValue({ managementToken: 'managementToken' })
+  mocks.getPath.mockImplementation(path => path)
+})
+
+const stubArgv = {
+  context: {
+    activeSpaceId: 'spaceId',
+    managementToken: 'managementToken'
+  },
+  skipContentModel: false,
+  skipLocales: false,
+  host: 'api.contentful.com',
+  skipContentPublishing: false,
+  skipContentUpdates: true,
+  skipAssetUpdates: true,
+  managementApplication: `contentful.cli/${version}`,
+  managementFeature: 'space-import',
+  uploadAssets: true,
+  assetsDirectory: 'assets'
+}
+
+test('it registers the bulk entries option', () => {
+  const yargs = {
+    usage: jest.fn().mockReturnThis(),
+    option: jest.fn().mockReturnThis(),
+    config: jest.fn().mockReturnThis(),
+    epilog: jest.fn().mockReturnThis()
   }
+
+  builder(yargs as never)
+
+  expect(yargs.option).toHaveBeenCalledWith(
+    'use-bulk-entries',
+    expect.objectContaining({ type: 'boolean', default: false })
+  )
+})
+
+test('it should pass all args to contentful-import', async () => {
   await importSpace(stubArgv)
   const result = {
     ...stubArgv,
@@ -45,4 +88,126 @@ test('it should pass all args to contentful-import', async () => {
   }
   expect(contentfulImport.mock.calls[0][0]).toEqual(result)
   expect(contentfulImport).toHaveBeenCalledTimes(1)
+  expect(importEntriesWithBulkOperations).not.toHaveBeenCalled()
+})
+
+test('it should import entries via bulk operations when --use-bulk-entries is set', async () => {
+  const entries = [{ sys: { id: 'e1', publishedVersion: 1 }, fields: {} }]
+  ;(createPlainClient as jest.Mock).mockResolvedValue({ raw: {} })
+
+  await importSpace({
+    ...stubArgv,
+    useBulkEntries: true,
+    content: {
+      contentTypes: [{ sys: { id: 'blogPost' } }],
+      entries
+    }
+  })
+
+  expect(contentfulImport).toHaveBeenCalledTimes(1)
+  expect(contentfulImport.mock.calls[0][0].content).toEqual({
+    contentTypes: [{ sys: { id: 'blogPost' } }],
+    entries: []
+  })
+  expect(contentfulImport.mock.calls[0][0].contentFile).toBeUndefined()
+  expect(contentfulImport.mock.calls[0][0].useBulkEntries).toBeUndefined()
+  expect(createPlainClient).toHaveBeenCalledTimes(1)
+  expect(importEntriesWithBulkOperations).toHaveBeenCalledWith(
+    expect.objectContaining({
+      entries,
+      skipContentPublishing: false,
+      skipContentUpdates: true,
+      transport: { mocked: true }
+    })
+  )
+})
+
+test('it should load bulk entries from content-file and use the selected environment', async () => {
+  const entries = [{ sys: { id: 'e1' }, fields: {} }]
+  mocks.readFileP.mockResolvedValue(JSON.stringify({ entries }) as never)
+  ;(createPlainClient as jest.Mock).mockResolvedValue({ raw: {} })
+
+  await importSpace({
+    ...stubArgv,
+    context: {
+      ...stubArgv.context,
+      activeEnvironmentId: 'staging'
+    },
+    contentFile: './export.json',
+    useBulkEntries: true
+  })
+
+  expect(mocks.getPath).toHaveBeenCalledWith('./export.json')
+  expect(mocks.readFileP).toHaveBeenCalledWith('./export.json', 'utf8')
+  expect(createPlainClient).toHaveBeenCalledWith(expect.any(Object), {
+    spaceId: 'spaceId',
+    environmentId: 'staging'
+  })
+  expect(importEntriesWithBulkOperations).toHaveBeenCalledWith(
+    expect.objectContaining({ entries })
+  )
+})
+
+test('it should return after the classic phase when there are no bulk entries', async () => {
+  const importResult = { imported: true }
+  ;(contentfulImport as jest.Mock).mockResolvedValue(importResult)
+
+  await expect(
+    importSpace({
+      ...stubArgv,
+      useBulkEntries: true,
+      content: { entries: [] }
+    })
+  ).resolves.toBe(importResult)
+
+  expect(createPlainClient).not.toHaveBeenCalled()
+  expect(importEntriesWithBulkOperations).not.toHaveBeenCalled()
+})
+
+test('it should treat a non-array entries property as empty', async () => {
+  await importSpace({
+    ...stubArgv,
+    useBulkEntries: true,
+    content: { entries: undefined }
+  })
+
+  expect(createPlainClient).not.toHaveBeenCalled()
+})
+
+test('it should require a content file when bulk content is not provided', async () => {
+  await expect(
+    importSpace({
+      ...stubArgv,
+      useBulkEntries: true,
+      content: undefined,
+      contentFile: undefined
+    })
+  ).rejects.toThrow('The --content-file option is required.')
+
+  expect(contentfulImport).not.toHaveBeenCalled()
+})
+
+test('it should not use bulk operations for --content-model-only', async () => {
+  await importSpace({
+    ...stubArgv,
+    useBulkEntries: true,
+    contentModelOnly: true,
+    content: { entries: [{ sys: { id: 'e1' } }] }
+  })
+
+  expect(contentfulImport).toHaveBeenCalledTimes(1)
+  expect(importEntriesWithBulkOperations).not.toHaveBeenCalled()
+})
+
+test('it should reject bulk import without a destination space before importing', async () => {
+  await expect(
+    importSpace({
+      ...stubArgv,
+      context: { managementToken: 'managementToken' },
+      useBulkEntries: true,
+      content: { entries: [{ sys: { id: 'e1' } }] }
+    })
+  ).rejects.toThrow('A destination space ID is required')
+
+  expect(contentfulImport).not.toHaveBeenCalled()
 })

--- a/test/unit/utils/bulk-entry-import.test.ts
+++ b/test/unit/utils/bulk-entry-import.test.ts
@@ -1,0 +1,867 @@
+import {
+  MAX_ENTITIES_PER_BULK_ACTION,
+  MAX_ENTRIES_PER_BULK_JOB,
+  BulkOperationEntityResult,
+  chunk,
+  createCmaBulkTransport,
+  importEntriesWithBulkOperations,
+  isPublishedInExport,
+  partitionEntries,
+  prepareEntryForCreate,
+  prepareEntryForUpdate
+} from '../../../lib/utils/bulk-entry-import'
+
+const sourceEntry = (
+  id: string,
+  extras: { publishedVersion?: number; title?: string } = {}
+) => ({
+  sys: {
+    id,
+    type: 'Entry',
+    version: 12,
+    publishedVersion: extras.publishedVersion,
+    space: { sys: { type: 'Link', linkType: 'Space', id: 'src' } },
+    contentType: {
+      sys: { type: 'Link', linkType: 'ContentType', id: 'blogPost' }
+    }
+  },
+  fields: { title: { 'en-US': extras.title || id } },
+  metadata: { tags: [] }
+})
+
+describe('chunk / prepare / partition', () => {
+  test('chunks items and rejects a non-positive size', () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]])
+    expect(() => chunk([1], 0)).toThrow('Chunk size must be greater than 0')
+  })
+
+  test('prepares create payloads without destination sys metadata', () => {
+    const prepared = prepareEntryForCreate(sourceEntry('a'))
+    expect(prepared.sys).toEqual({
+      type: 'Entry',
+      id: 'a',
+      contentType: {
+        sys: { type: 'Link', linkType: 'ContentType', id: 'blogPost' }
+      }
+    })
+    expect(prepared.fields).toEqual({ title: { 'en-US': 'a' } })
+    expect(prepared.metadata).toEqual({ tags: [] })
+  })
+
+  test('prepares update payloads with the destination version', () => {
+    expect(prepareEntryForUpdate(sourceEntry('a'), 3).sys?.version).toBe(3)
+  })
+
+  test('prepares minimal entries with empty fields', () => {
+    expect(prepareEntryForCreate({ sys: { id: 'minimal' } })).toEqual({
+      sys: { type: 'Entry', id: 'minimal' },
+      fields: {}
+    })
+    expect(prepareEntryForCreate({})).toEqual({
+      sys: { type: 'Entry' },
+      fields: {}
+    })
+  })
+
+  test('treats publishedVersion as the export publish signal', () => {
+    expect(isPublishedInExport(sourceEntry('draft'))).toBe(false)
+    expect(
+      isPublishedInExport(sourceEntry('live', { publishedVersion: 11 }))
+    ).toBe(true)
+  })
+
+  test('splits create vs update and honors skipContentUpdates', () => {
+    const destination = new Map([
+      ['existing', 4],
+      ['skip-me', 1]
+    ])
+    const { toCreate, toUpdate } = partitionEntries(
+      [sourceEntry('existing'), sourceEntry('fresh'), sourceEntry('skip-me')],
+      destination
+    )
+    expect(toCreate.map(entry => entry.sys?.id)).toEqual(['fresh'])
+    expect(toUpdate.map(entry => entry.sys?.id)).toEqual([
+      'existing',
+      'skip-me'
+    ])
+    expect(toUpdate[0].sys?.version).toBe(4)
+
+    const skipped = partitionEntries(
+      [sourceEntry('existing'), sourceEntry('fresh')],
+      destination,
+      true
+    )
+    expect(skipped.toCreate.map(entry => entry.sys?.id)).toEqual(['fresh'])
+    expect(skipped.toUpdate).toEqual([])
+  })
+
+  test('rejects entries without IDs', () => {
+    expect(() => partitionEntries([{ fields: {} }], new Map())).toThrow(
+      'Entry at index 0 does not include sys.id'
+    )
+  })
+})
+
+function createTransport(overrides: Record<string, jest.Mock> = {}) {
+  const operations = new Map<
+    string,
+    {
+      sys: { id: string; status: string }
+      result: { items: BulkOperationEntityResult[] }
+    }
+  >()
+  let opCount = 0
+
+  const transport = {
+    listEntryVersions: jest.fn().mockResolvedValue(new Map()),
+    uploadEntries: jest.fn().mockImplementation(async (entries: unknown[]) => {
+      return `upload-${entries.length}`
+    }),
+    createBulkOperation: jest
+      .fn()
+      .mockImplementation(async (action: string) => {
+        opCount += 1
+        const id = `${action}-${opCount}`
+        operations.set(id, {
+          sys: { id, status: 'in_progress' },
+          result: { items: [] }
+        })
+        return { sys: { id, status: 'in_progress' } }
+      }),
+    getBulkOperation: jest.fn().mockImplementation(async (id: string) => {
+      const current = operations.get(id)
+      current.sys.status = 'completed'
+      return current
+    }),
+    publishEntries: jest.fn().mockResolvedValue(undefined),
+    ...overrides
+  }
+
+  return { transport, operations }
+}
+
+describe('importEntriesWithBulkOperations', () => {
+  test('creates, updates and publishes in bulk batches', async () => {
+    const created = Array.from(
+      { length: MAX_ENTRIES_PER_BULK_JOB + 1 },
+      (_, i) => sourceEntry(`new-${i}`, { publishedVersion: 1 })
+    )
+    const updated = [sourceEntry('existing', { publishedVersion: 5 })]
+    const draft = [sourceEntry('draft-only')]
+    const { transport, operations } = createTransport()
+
+    transport.listEntryVersions.mockResolvedValue(new Map([['existing', 2]]))
+    transport.createBulkOperation.mockImplementation(async (action: string) => {
+      const id = `${action}-${operations.size + 1}`
+      operations.set(id, {
+        sys: { id, status: 'in_progress' },
+        result: { items: [] }
+      })
+      return { sys: { id, status: 'in_progress' } }
+    })
+    transport.getBulkOperation.mockImplementation(async (id: string) => {
+      const current = operations.get(id)
+      current.sys.status = 'completed'
+      if (id.startsWith('create')) {
+        current.result.items = created.map(entry => ({
+          status: 'succeeded',
+          entity: { sys: { id: entry.sys.id, version: 1 } }
+        }))
+        current.result.items[0].entity.sys.version = 1
+        current.result.items[created.length - 1] = {
+          status: 'succeeded',
+          entity: {
+            sys: { id: created[created.length - 1].sys.id, version: 1 }
+          }
+        }
+      }
+      if (id.startsWith('update')) {
+        current.result.items = [
+          {
+            status: 'succeeded',
+            entity: { sys: { id: 'existing' } }
+          }
+        ]
+      }
+      return current
+    })
+
+    const result = await importEntriesWithBulkOperations({
+      entries: [...created, ...updated, ...draft],
+      transport,
+      sleep: async () => undefined,
+      pollIntervalMs: 0,
+      logger: { log: jest.fn(), warning: jest.fn() }
+    })
+
+    expect(transport.uploadEntries).toHaveBeenCalledTimes(3)
+    expect(transport.uploadEntries.mock.calls[0][0]).toHaveLength(
+      MAX_ENTRIES_PER_BULK_JOB
+    )
+    expect(transport.uploadEntries.mock.calls[1][0]).toHaveLength(2)
+    expect(
+      transport.createBulkOperation.mock.calls.map(call => call[0])
+    ).toEqual(['create', 'create', 'update'])
+    expect(result).toEqual({
+      created: created.length + draft.length,
+      updated: 1,
+      published: created.length + 1,
+      failures: []
+    })
+    expect(transport.publishEntries.mock.calls.length).toBe(
+      Math.ceil((created.length + 1) / MAX_ENTITIES_PER_BULK_ACTION)
+    )
+    expect(transport.publishEntries.mock.calls[0][0]).toHaveLength(
+      MAX_ENTITIES_PER_BULK_ACTION
+    )
+    expect(
+      transport.publishEntries.mock.calls.flatMap(call => call[0])
+    ).toContainEqual({ id: 'existing', version: 3 })
+  })
+
+  test('skips publishing and updates when those flags are set', async () => {
+    const { transport } = createTransport()
+    transport.listEntryVersions.mockResolvedValue(new Map([['existing', 1]]))
+    transport.getBulkOperation.mockResolvedValue({
+      sys: { id: 'create-1', status: 'completed' },
+      result: {
+        items: [
+          { status: 'succeeded', entity: { sys: { id: 'fresh', version: 1 } } }
+        ]
+      }
+    })
+
+    const result = await importEntriesWithBulkOperations({
+      entries: [
+        sourceEntry('fresh', { publishedVersion: 1 }),
+        sourceEntry('existing', { publishedVersion: 1 })
+      ],
+      transport,
+      skipContentPublishing: true,
+      skipContentUpdates: true,
+      sleep: async () => undefined,
+      logger: { log: jest.fn(), warning: jest.fn() }
+    })
+
+    expect(transport.createBulkOperation).toHaveBeenCalledWith(
+      'create',
+      expect.any(String)
+    )
+    expect(transport.createBulkOperation).not.toHaveBeenCalledWith(
+      'update',
+      expect.any(String)
+    )
+    expect(transport.publishEntries).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      created: 1,
+      updated: 0,
+      published: 0,
+      failures: []
+    })
+  })
+
+  test('throws after logging per-item failures', async () => {
+    const warnings: string[] = []
+    const { transport } = createTransport()
+    transport.getBulkOperation.mockResolvedValue({
+      sys: { id: 'create-1', status: 'completed' },
+      result: {
+        items: [
+          {
+            status: 'failed',
+            error: { message: 'Validation error' }
+          }
+        ]
+      }
+    })
+
+    await expect(
+      importEntriesWithBulkOperations({
+        entries: [sourceEntry('bad')],
+        transport,
+        sleep: async () => undefined,
+        logger: { log: jest.fn(), warning: msg => warnings.push(String(msg)) }
+      })
+    ).rejects.toMatchObject({
+      name: 'BulkEntryImportError',
+      failures: ['bad: Validation error']
+    })
+    expect(warnings[0]).toContain('bad: Validation error')
+  })
+
+  test('times out when a job never completes', async () => {
+    const { transport } = createTransport()
+    transport.getBulkOperation.mockResolvedValue({
+      sys: { id: 'create-1', status: 'in_progress' }
+    })
+
+    await expect(
+      importEntriesWithBulkOperations({
+        entries: [sourceEntry('slow')],
+        transport,
+        sleep: async () => undefined,
+        pollIntervalMs: 1,
+        pollTimeoutMs: 5,
+        logger: { log: jest.fn(), warning: jest.fn() }
+      })
+    ).rejects.toThrow(/Timed out waiting for bulk create/)
+  })
+
+  test.each(['failed', 'cancelled', 'canceled'])(
+    'rejects a bulk job with %s status',
+    async status => {
+      const { transport } = createTransport()
+      transport.createBulkOperation.mockResolvedValue({
+        sys: { id: 'create-1', status }
+      })
+
+      await expect(
+        importEntriesWithBulkOperations({
+          entries: [sourceEntry('bad-job')],
+          transport,
+          sleep: async () => undefined,
+          logger: { log: jest.fn(), warning: jest.fn() }
+        })
+      ).rejects.toThrow(`Bulk create operation create-1 ${status}`)
+    }
+  )
+
+  test('rejects a bulk job response without an id', async () => {
+    const { transport } = createTransport()
+    transport.createBulkOperation.mockResolvedValue({
+      sys: { status: 'in_progress' }
+    })
+
+    await expect(
+      importEntriesWithBulkOperations({
+        entries: [sourceEntry('missing-operation-id')],
+        transport,
+        logger: { log: jest.fn(), warning: jest.fn() }
+      })
+    ).rejects.toThrow('operation response did not include an id')
+  })
+
+  test('uses error codes and fallback messages for unidentified failures', async () => {
+    const warnings: string[] = []
+    const { transport } = createTransport()
+    transport.getBulkOperation.mockResolvedValue({
+      sys: { id: 'create-1', status: 'completed' },
+      result: {
+        items: [
+          { status: 'failed', error: { sys: { id: 'InvalidEntry' } } },
+          { status: 'failed' }
+        ]
+      }
+    })
+
+    await expect(
+      importEntriesWithBulkOperations({
+        entries: [sourceEntry('coded')],
+        transport,
+        sleep: async () => undefined,
+        logger: {
+          log: jest.fn(),
+          warning: value => warnings.push(String(value))
+        }
+      })
+    ).rejects.toMatchObject({
+      failures: ['coded: InvalidEntry', 'unknown error']
+    })
+    expect(warnings).toHaveLength(2)
+  })
+
+  test('handles missing results and unidentified successful result items', async () => {
+    const { transport } = createTransport()
+    transport.getBulkOperation
+      .mockResolvedValueOnce({ sys: { id: 'create-1', status: 'completed' } })
+      .mockResolvedValueOnce({
+        sys: { id: 'create-1', status: 'completed' },
+        result: {
+          items: [{ status: 'succeeded', entity: { sys: { id: 'known' } } }, {}]
+        }
+      })
+
+    await expect(
+      importEntriesWithBulkOperations({
+        entries: [sourceEntry('without-results')],
+        transport,
+        sleep: async () => undefined,
+        logger: { log: jest.fn(), warning: jest.fn() }
+      })
+    ).resolves.toMatchObject({ created: 1 })
+
+    await expect(
+      importEntriesWithBulkOperations({
+        entries: [sourceEntry('submitted')],
+        transport,
+        sleep: async () => undefined,
+        logger: { log: jest.fn(), warning: jest.fn() }
+      })
+    ).resolves.toMatchObject({ created: 1 })
+  })
+
+  test('polls an operation whose initial status is omitted', async () => {
+    const { transport } = createTransport()
+    transport.createBulkOperation.mockResolvedValue({ sys: { id: 'create-1' } })
+    transport.getBulkOperation.mockResolvedValue({
+      sys: { id: 'create-1', status: 'completed' }
+    })
+
+    await expect(
+      importEntriesWithBulkOperations({
+        entries: [sourceEntry('no-initial-status')],
+        transport,
+        sleep: async () => undefined,
+        logger: { log: jest.fn(), warning: jest.fn() }
+      })
+    ).resolves.toMatchObject({ created: 1 })
+  })
+
+  test('uses the default polling options and logger', async () => {
+    const setTimeoutSpy = jest
+      .spyOn(global, 'setTimeout')
+      .mockImplementation((callback: (...args: unknown[]) => void) => {
+        callback()
+        return 0 as unknown as NodeJS.Timeout
+      })
+    const { transport } = createTransport()
+    await expect(
+      importEntriesWithBulkOperations({
+        entries: [sourceEntry('default-options')],
+        transport
+      })
+    ).resolves.toMatchObject({ created: 1 })
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2000)
+    setTimeoutSpy.mockRestore()
+  })
+
+  test('does nothing when there are no entries', async () => {
+    const { transport } = createTransport()
+    const result = await importEntriesWithBulkOperations({
+      entries: [],
+      transport,
+      logger: { log: jest.fn(), warning: jest.fn() }
+    })
+    expect(result.created).toBe(0)
+    expect(transport.listEntryVersions).not.toHaveBeenCalled()
+  })
+})
+
+describe('createCmaBulkTransport', () => {
+  test('lists versions, uploads, starts jobs and publishes through the CMA client', async () => {
+    const client = {
+      entry: {
+        getMany: jest.fn().mockResolvedValueOnce({
+          items: [{ sys: { id: 'a', version: 2 } }],
+          total: 1
+        })
+      },
+      upload: {
+        create: jest.fn().mockResolvedValue({ sys: { id: 'up1' } })
+      },
+      bulkAction: {
+        publish: jest
+          .fn()
+          .mockResolvedValue({ sys: { id: 'ba1', status: 'succeeded' } }),
+        get: jest.fn()
+      },
+      raw: {
+        get: jest.fn(),
+        post: jest.fn().mockResolvedValue({
+          data: { sys: { id: 'op1', status: 'in_progress' } }
+        })
+      }
+    }
+
+    const transport = createCmaBulkTransport({
+      client,
+      spaceId: 'space',
+      environmentId: 'master'
+    })
+
+    await expect(transport.listEntryVersions()).resolves.toEqual(
+      new Map([['a', 2]])
+    )
+    await expect(transport.uploadEntries([{ sys: { id: 'a' } }])).resolves.toBe(
+      'up1'
+    )
+    expect(client.upload.create).toHaveBeenCalledWith(
+      { spaceId: 'space', environmentId: 'master' },
+      { file: expect.any(ArrayBuffer) }
+    )
+    await expect(
+      transport.createBulkOperation('create', 'up1')
+    ).resolves.toEqual({
+      sys: { id: 'op1', status: 'in_progress' }
+    })
+    expect(client.raw.post).toHaveBeenCalledWith(
+      '/spaces/space/environments/master/bulk_operations/entries/create',
+      {
+        upload: {
+          sys: { type: 'Upload', id: 'up1' }
+        }
+      }
+    )
+
+    await transport.publishEntries([{ id: 'a', version: 1 }], {
+      sleep: async () => undefined,
+      pollIntervalMs: 0,
+      pollTimeoutMs: 100
+    })
+    expect(client.bulkAction.publish).toHaveBeenCalled()
+  })
+
+  test('maps a 403 from bulk operations to a Premium entitlement error', async () => {
+    const client = {
+      raw: {
+        get: jest.fn(),
+        post: jest.fn().mockRejectedValue({ response: { status: 403 } })
+      }
+    }
+
+    const transport = createCmaBulkTransport({
+      client,
+      spaceId: 'space',
+      environmentId: 'master'
+    })
+
+    await expect(
+      transport.createBulkOperation('create', 'up1')
+    ).rejects.toThrow(/Bulk Content Operations \(Premium\)/)
+  })
+
+  test('maps serialized SDK 403 errors to a Premium entitlement error', async () => {
+    const client = {
+      raw: {
+        get: jest.fn(),
+        post: jest.fn().mockRejectedValue(
+          Object.assign(new Error(JSON.stringify({ status: 403 })), {
+            name: 'Forbidden'
+          })
+        )
+      }
+    }
+
+    const transport = createCmaBulkTransport({
+      client,
+      spaceId: 'space',
+      environmentId: 'master'
+    })
+
+    await expect(
+      transport.createBulkOperation('update', 'up1')
+    ).rejects.toThrow(/Bulk Content Operations \(Premium\)/)
+  })
+
+  test.each([
+    Object.assign(new Error('not json'), { name: '403 Forbidden' }),
+    { status: 403 },
+    { message: JSON.stringify({ status: 403 }) },
+    { message: JSON.stringify({}), name: '403 Forbidden' }
+  ])('recognizes supported 403 error shapes', async error => {
+    const client = {
+      raw: {
+        get: jest.fn(),
+        post: jest.fn().mockRejectedValue(error)
+      }
+    }
+    const transport = createCmaBulkTransport({
+      client,
+      spaceId: 'space',
+      environmentId: 'master'
+    })
+
+    await expect(
+      transport.createBulkOperation('create', 'up1')
+    ).rejects.toThrow(/Bulk Content Operations \(Premium\)/)
+  })
+
+  test.each([null, 'network error', new Error('not json'), {}])(
+    'preserves non-CMA errors',
+    async error => {
+      const client = {
+        raw: {
+          get: jest.fn(),
+          post: jest.fn().mockRejectedValue(error)
+        }
+      }
+      const transport = createCmaBulkTransport({
+        client,
+        spaceId: 'space',
+        environmentId: 'master'
+      })
+
+      await expect(transport.createBulkOperation('create', 'up1')).rejects.toBe(
+        error
+      )
+    }
+  )
+
+  test('paginates entry versions and ignores incomplete items', async () => {
+    const firstPage = Array.from({ length: 1000 }, (_, index) => ({
+      sys: { id: `entry-${index}`, version: index + 1 }
+    }))
+    const client = {
+      entry: {
+        getMany: jest
+          .fn()
+          .mockResolvedValueOnce({ items: firstPage, total: 1002 })
+          .mockResolvedValueOnce({
+            items: [
+              { sys: { id: 'last', version: 2 } },
+              { sys: { id: 'no-version' } }
+            ],
+            total: 1002
+          })
+      },
+      raw: { get: jest.fn(), post: jest.fn() }
+    }
+    const transport = createCmaBulkTransport({
+      client,
+      spaceId: 'space',
+      environmentId: 'master'
+    })
+
+    const versions = await transport.listEntryVersions()
+    expect(client.entry.getMany).toHaveBeenCalledTimes(2)
+    expect(versions.size).toBe(1001)
+    expect(versions.get('last')).toBe(2)
+  })
+
+  test('lists entry versions through the raw fallback', async () => {
+    const client = {
+      entry: {},
+      raw: {
+        get: jest.fn().mockResolvedValue({
+          data: { items: [{ sys: { id: 'raw', version: 4 } }] }
+        }),
+        post: jest.fn()
+      }
+    }
+    const transport = createCmaBulkTransport({
+      client,
+      spaceId: 'space',
+      environmentId: 'master'
+    })
+
+    await expect(transport.listEntryVersions()).resolves.toEqual(
+      new Map([['raw', 4]])
+    )
+  })
+
+  test('handles an empty entry page without pagination metadata', async () => {
+    const client = {
+      entry: {
+        getMany: jest.fn().mockResolvedValue({})
+      },
+      raw: { get: jest.fn(), post: jest.fn() }
+    }
+    const transport = createCmaBulkTransport({
+      client,
+      spaceId: 'space',
+      environmentId: 'master'
+    })
+
+    await expect(transport.listEntryVersions()).resolves.toEqual(new Map())
+  })
+
+  test('stops when an entry page omits items despite a larger total', async () => {
+    const client = {
+      entry: {
+        getMany: jest.fn().mockResolvedValue({ total: 1001 })
+      },
+      raw: { get: jest.fn(), post: jest.fn() }
+    }
+    const transport = createCmaBulkTransport({
+      client,
+      spaceId: 'space',
+      environmentId: 'master'
+    })
+
+    await expect(transport.listEntryVersions()).resolves.toEqual(new Map())
+    expect(client.entry.getMany).toHaveBeenCalledTimes(1)
+  })
+
+  test.each(['sdk', 'raw'])('rejects %s uploads without an id', async mode => {
+    const client = {
+      upload:
+        mode === 'sdk'
+          ? { create: jest.fn().mockResolvedValue({ sys: {} }) }
+          : undefined,
+      raw: {
+        get: jest.fn(),
+        post: jest.fn().mockResolvedValue({ data: { sys: {} } })
+      }
+    }
+    const transport = createCmaBulkTransport({
+      client,
+      spaceId: 'space',
+      environmentId: 'master'
+    })
+
+    await expect(transport.uploadEntries([])).rejects.toThrow(
+      'Upload API did not return an id'
+    )
+  })
+
+  test('uses the environment upload endpoint in the raw fallback', async () => {
+    const client = {
+      raw: {
+        get: jest.fn(),
+        post: jest.fn().mockResolvedValue({ data: { sys: { id: 'up1' } } })
+      }
+    }
+    const transport = createCmaBulkTransport({
+      client,
+      spaceId: 'space',
+      environmentId: 'staging'
+    })
+
+    await expect(transport.uploadEntries([])).resolves.toBe('up1')
+    expect(client.raw.post).toHaveBeenCalledWith(
+      '/spaces/space/environments/staging/uploads',
+      expect.any(ArrayBuffer),
+      { headers: { 'Content-Type': 'application/octet-stream' } }
+    )
+  })
+
+  test('polls raw bulk publish actions until they succeed', async () => {
+    const client = {
+      raw: {
+        get: jest.fn().mockResolvedValue({
+          data: { sys: { id: 'publish-1', status: 'succeeded' } }
+        }),
+        post: jest.fn().mockResolvedValue({
+          data: { sys: { id: 'publish-1', status: 'inProgress' } }
+        })
+      }
+    }
+    const transport = createCmaBulkTransport({
+      client,
+      spaceId: 'space',
+      environmentId: 'master'
+    })
+
+    await transport.publishEntries([{ id: 'a', version: 1 }], {
+      sleep: async () => undefined,
+      pollIntervalMs: 0,
+      pollTimeoutMs: 100
+    })
+
+    expect(client.raw.get).toHaveBeenCalledWith(
+      '/spaces/space/environments/master/bulk_actions/actions/publish-1'
+    )
+  })
+
+  test('unwraps direct raw operation responses', async () => {
+    const operation = { sys: { id: 'operation-1', status: 'completed' } }
+    const client = {
+      raw: {
+        get: jest.fn().mockResolvedValue(operation),
+        post: jest.fn().mockResolvedValue(operation)
+      }
+    }
+    const transport = createCmaBulkTransport({
+      client,
+      spaceId: 'space',
+      environmentId: 'master'
+    })
+
+    await expect(transport.getBulkOperation('operation-1')).resolves.toBe(
+      operation
+    )
+    await expect(
+      transport.createBulkOperation('create', 'upload-1')
+    ).resolves.toBe(operation)
+  })
+
+  test('polls SDK bulk publish actions until they succeed', async () => {
+    const client = {
+      bulkAction: {
+        publish: jest.fn().mockResolvedValue({
+          sys: { id: 'publish-1', status: 'inProgress' }
+        }),
+        get: jest.fn().mockResolvedValue({
+          sys: { id: 'publish-1', status: 'succeeded' }
+        })
+      },
+      raw: { get: jest.fn(), post: jest.fn() }
+    }
+    const transport = createCmaBulkTransport({
+      client,
+      spaceId: 'space',
+      environmentId: 'master'
+    })
+
+    await transport.publishEntries([{ id: 'a', version: 1 }], {
+      sleep: async () => undefined,
+      pollIntervalMs: 0,
+      pollTimeoutMs: 100
+    })
+    expect(client.bulkAction.get).toHaveBeenCalledTimes(1)
+  })
+
+  test('polls a bulk publish action whose initial status is omitted', async () => {
+    const client = {
+      bulkAction: {
+        publish: jest.fn().mockResolvedValue({ sys: { id: 'publish-1' } }),
+        get: jest.fn().mockResolvedValue({
+          sys: { id: 'publish-1', status: 'succeeded' }
+        })
+      },
+      raw: { get: jest.fn(), post: jest.fn() }
+    }
+    const transport = createCmaBulkTransport({
+      client,
+      spaceId: 'space',
+      environmentId: 'master'
+    })
+
+    await transport.publishEntries([{ id: 'a', version: 1 }], {
+      sleep: async () => undefined,
+      pollIntervalMs: 0,
+      pollTimeoutMs: 100
+    })
+    expect(client.bulkAction.get).toHaveBeenCalledTimes(1)
+  })
+
+  test('rejects failed, missing-id and timed-out bulk publish actions', async () => {
+    const client = {
+      bulkAction: {
+        publish: jest.fn()
+      },
+      raw: { get: jest.fn(), post: jest.fn() }
+    }
+    const transport = createCmaBulkTransport({
+      client,
+      spaceId: 'space',
+      environmentId: 'master'
+    })
+    const waitOptions = {
+      sleep: async () => undefined,
+      pollIntervalMs: 0,
+      pollTimeoutMs: -1
+    }
+
+    client.bulkAction.publish.mockResolvedValueOnce({
+      sys: { status: 'created' }
+    })
+    await expect(
+      transport.publishEntries([{ id: 'a', version: 1 }], waitOptions)
+    ).rejects.toThrow('Bulk publish did not return an id')
+
+    client.bulkAction.publish.mockResolvedValueOnce({
+      sys: { id: 'failed-1', status: 'failed' }
+    })
+    await expect(
+      transport.publishEntries([{ id: 'a', version: 1 }], waitOptions)
+    ).rejects.toThrow('Bulk publish failed-1 failed')
+
+    client.bulkAction.publish.mockResolvedValueOnce({
+      sys: { id: 'slow-1', status: 'created' }
+    })
+    await expect(
+      transport.publishEntries([{ id: 'a', version: 1 }], waitOptions)
+    ).rejects.toThrow('Timed out waiting for bulk publish slow-1')
+  })
+})


### PR DESCRIPTION
## Summary

Adds an opt-in bulk entry import path for large Contentful restores, as proposed in #3331.

The new `--use-bulk-entries` flag:

- Keeps content models, locales, tags, editor interfaces, and assets on the existing `contentful-import` path
- Creates and updates entries through Bulk Entry Operations in batches of up to 10,000
- Publishes previously published entries through Bulk Actions in batches of up to 200
- Preserves `--skip-content-updates`, `--skip-content-publishing`, and `--content-model-only`
- Reports an actionable error when Bulk Content Operations is not enabled

The existing import behavior remains unchanged unless the flag is explicitly enabled.

## Design

- Partitions entries into create and update groups using destination IDs and versions
- Uses environment-scoped uploads
- Polls asynchronous operations until completion or failure
- Handles per-entry failures from completed bulk jobs
- Runs bulk entry jobs sequentially because only one may be active per space
- Does not silently fall back to classic entry imports after an entitlement error
- Documents the decisions and trade-offs in an ADR

## Usage

```sh
contentful space import \
  --space-id '<space-id>' \
  --environment-id '<environment-id>' \
  --content-file './export.json' \
  --use-bulk-entries